### PR TITLE
Fixing DenDai contract to pass tests.

### DIFF
--- a/contracts/DenDai/DenDai.sol
+++ b/contracts/DenDai/DenDai.sol
@@ -75,6 +75,8 @@ contract DenDai is ERC20Mintable {
 
   //wrapped ETH functions borrowed from
   //https://etherscan.io/address/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2#code
+  mapping (address => uint) public _balances;
+
   function() public payable {
       deposit();
   }


### PR DESCRIPTION
Ran into a small thing while setting the project up. Quick fix to get ```clevis test full``` working.

Otherwise was getting the following compile error:

```ERROR compiling! {}
{ contracts: {},
  errors:
   [ 'DenDai.sol:33:37: Warning: This declaration shadows an existing declaration.\n  function addVendor(address wallet,bytes32 name) public {\n                                    ^----------^\nDenDai.sol:7:3: The shadowed declaration is here:\n  string public name = "DenDai";\n  ^---------------------------^\n\n',
     'DenDai.sol:42:41: Warning: This declaration shadows an existing declaration.\n  function updateVendor(address wallet, bytes32 name, bool newAllowed) public {\n                                        ^----------^\nDenDai.sol:7:3: The shadowed declaration is here:\n  string public name = "DenDai";\n  ^---------------------------^\n\n',
     'DenDai.sol:62:35: Warning: This declaration shadows an existing declaration.\n  function addProduct(uint256 id, bytes32 name, uint256 cost, bool isAvailable) public {\n                                  ^----------^\nDenDai.sol:7:3: The shadowed declaration is here:\n  string public name = "DenDai";\n  ^---------------------------^\n\n',
     'DenDai.sol:82:5: DeclarationError: Undeclared identifier.\n    _balances[msg.sender] += msg.value;\n    ^-------^\n',
     'DenDai.sol:89:13: DeclarationError: Undeclared identifier.\n    require(_balances[msg.sender] >= wad);\n            ^-------^\n',
     'DenDai.sol:90:5: DeclarationError: Undeclared identifier.\n    _balances[msg.sender] -= wad;\n    ^-------^\n' ],
  sourceList:
   [ 'DenDai.sol',
     'openzeppelin-solidity/contracts/access/Roles.sol',
     'openzeppelin-solidity/contracts/access/roles/MinterRole.sol',
     'openzeppelin-solidity/contracts/math/SafeMath.sol',
     'openzeppelin-solidity/contracts/ownership/Ownable.sol',
     'openzeppelin-solidity/contracts/token/ERC20/ERC20.sol',
     'openzeppelin-solidity/contracts/token/ERC20/ERC20Mintable.sol',
     'openzeppelin-solidity/contracts/token/ERC20/IERC20.sol' ],
  sources: {} }
    1) should compile DenDai contract to bytecode

  2 passing (11s)
  1 failing```

Easy patch for now until we end up actually writing the stable code for this.