### PR TITLE
resolve ENS names in "To Address" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "ethereum-mnemonic-privatekey-utils": "^1.0.5",
     "ethereumjs-tx": "^1.3.7",
     "ethereumjs-util": "^6.0.0",
+    "ethers": "^4.0.20",
     "express": "^4.16.4",
     "fs": "0.0.1-security",
     "helmet": "^3.14.0",

--- a/src/components/SendToAddress.js
+++ b/src/components/SendToAddress.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Ruler from "./Ruler";
 import Balance from "./Balance";
 import Blockies from 'react-blockies';
+import { ethers } from 'ethers';
 
 
 export default class SendToAddress extends React.Component {
@@ -40,6 +41,7 @@ export default class SendToAddress extends React.Component {
     this.state = initialState
     console.log("SendToAddress constructor",this.state)
     window.history.pushState({},"", "/");
+    this.ensProvider = ethers.getDefaultProvider('homestead');
   }
 
   updateState = (key, value) => {
@@ -75,15 +77,21 @@ export default class SendToAddress extends React.Component {
     },1500)
   }
 
-  canSend() {
+  async canSend() {
+    const resolvedAddress = await this.ensProvider.resolveName(this.state.toAddress)
+    console.log(`RESOLVED ADDRESS ${resolvedAddress}`)
+    if(resolvedAddress != null){
+      this.setState({
+        toAddress: resolvedAddress
+      })
+    }
     return (this.state.toAddress && this.state.toAddress.length === 42)
   }
 
-  send = () => {
+  send = async () => {
     let { toAddress, amount } = this.state;
 
-
-    if(this.state.canSend){
+    if(await this.state.canSend){
       if(this.props.balance-0.0001<=amount){
         let extraHint = ""
         if(amount-this.props.balance<=.01){
@@ -120,7 +128,7 @@ export default class SendToAddress extends React.Component {
         })
       }
     }else{
-      this.props.changeAlert({type: 'warning', message: 'Please enter a valid address'})
+      this.props.changeAlert({type: 'warning', message: 'Please enter a valid address or ENS domain'})
     }
   };
 


### PR DESCRIPTION
Fixes: #63 

Won't let you proceed with an ENS name that doesn't resolve to anything, if the ENS name resolves it will be replaced in the To Address field with the address, so you can be aware if the address on the resolver has changed.