### PR TITLE
enable apple-mobile-web-app-capable

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8" />
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black"/>
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -56,5 +56,6 @@
   "start_url": "./index.html",
   "orientation": "portrait",
   "theme_color": "#fd7e14",
-  "background_color": "#fd7e14"
+  "background_color": "#fd7e14",
+  "display": "standalone"
 }


### PR DESCRIPTION
This would make a Home Screen link open without the safari window chrome, to feel more native.

Is there a security issue in this? I mean you won't know if you're
getting MITM’d  in safari either, and if this encourages bookmarking
and _not_ following links to a funny looking domain, then that's safer. 

Safari and the PWA/home-screen instances have different 
sandboxes entirely though, so this sort of complicates link-handling. 
A user clicking a link to receive funds would have to funnel through their 
second safari wallet to the PWA wallet. 

**I'm not really sure if there's UX gains here or in #11 versus going full React Native.** And maybe not even full RN? There is a lot of elegance in basic web only. 🤔 


Honestly I couldn't even get the app to load from my phone over LAN, with or without PWA mode enabled. (Was loading & sending funds on simulator just fine, but testing "Link" button hung at 100% progress, unsure why, running low on steam tonight)

Figured it was worth pushing what I'd done and the results of the investigation (doesn't look great for this direction IMO).

![burner_mobile-web-app-capable](https://user-images.githubusercontent.com/169076/53675731-d5055680-3c5e-11e9-8bd4-37c8d38b2207.gif)
