### PR TITLE
Adding meta-tags for web app support in iOS

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,11 @@
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
     <meta name="theme-color" content="#fd7e14" />
+
+    <link rel="apple-touch-icon" href="/icons/icon-512x512.png">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black">
+
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <link
       rel="stylesheet"


### PR DESCRIPTION
Small PR to put my toes in the water. Allows you to add a native iOS icon on your home screen that should open the app in full screen mode