### PR TITLE
Wyre UI/UX Improvements (#116)

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -148,16 +148,38 @@ i.fas {
 }
 
 /** SLIDER STYLE OVERRIDES **/
+.wyre-slider .input-range__slider {
+    width: 18px;
+    height: 18px;
+    margin-left: -9px;
+    margin-top: -11px;
+}
+
+@media only screen and (max-width: 500px) {
+    .wyre-slider .input-range__slider {
+        width: 24px;
+        height: 24px;
+        margin-left: -12px;
+        margin-top: -15px;
+    }
+}
+
 .wyre-slider .input-range__label--min,
 .wyre-slider .input-range__label--max {
     bottom: -1.8rem;
+}
+
+@media only screen and (max-width: 500px) {
+    .wyre-slider .input-range__label--min,
+    .wyre-slider .input-range__label--max {
+        bottom: -2.1rem;
+    }
 }
 
 .wyre-slider .input-range__label {
     font-size: 16px!important;
     font-weight: normal!important;
     letter-spacing: .1px!important;
-    
     -webkit-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;

--- a/src/App.scss
+++ b/src/App.scss
@@ -148,17 +148,18 @@ i.fas {
 }
 
 /** SLIDER STYLE OVERRIDES **/
-.input-range__label--max {
-    padding-right: 12px;
+.wyre-slider .input-range__label--min,
+.wyre-slider .input-range__label--max {
+    bottom: -1.8rem;
 }
 
-.input-range__label {
+.wyre-slider .input-range__label {
     font-size: 16px!important;
     font-weight: normal!important;
     letter-spacing: .1px!important;
 }
 
-.input-range__label--value {
+.wyre-slider .input-range__label--value {
     display: none!important;
 }
 

--- a/src/App.scss
+++ b/src/App.scss
@@ -164,11 +164,19 @@ i.fas {
 
 
 /** Wyre **/
+.wyre-button--font-size {
+    font-size: 16px;
+}
+
 .wyre-sublabel--font-size {
     font-size: 12px;
 }
 
 @media only screen and (max-width: 450px) {
+    .wyre-button--font-size {
+        font-size: 13px;
+    }
+
     .wyre-sublabel--font-size {
         font-size: 10px;
     }

--- a/src/App.scss
+++ b/src/App.scss
@@ -157,6 +157,11 @@ i.fas {
     font-size: 16px!important;
     font-weight: normal!important;
     letter-spacing: .1px!important;
+    
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 
 .wyre-slider .input-range__label--value {

--- a/src/App.scss
+++ b/src/App.scss
@@ -161,3 +161,15 @@ i.fas {
 .input-range__label--value {
     display: none!important;
 }
+
+
+/** Wyre **/
+.wyre-sublabel--font-size {
+    font-size: 12px;
+}
+
+@media only screen and (max-width: 450px) {
+    .wyre-sublabel--font-size {
+        font-size: 10px;
+    }
+}

--- a/src/components/Exchange.js
+++ b/src/components/Exchange.js
@@ -2221,12 +2221,12 @@ export default class Exchange extends React.Component {
             <div className="col-3 p-1" style={{marginTop:8}}>
               xDai
             </div>
-            <div className="col-5 p-1" style={{marginTop:8,whiteSpace:"nowrap"}}>
+            <div className="col-4 p-1" style={{marginTop:8,whiteSpace:"nowrap"}}>
                 <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
                   ${this.props.dollarDisplay(this.props.xdaiBalance)}
                 </Scaler>
             </div>
-            <div className="col-2 p-1" style={{marginTop:8}}>
+            <div className="col-3 p-1" style={{marginTop:8}}>
               {sendXdaiButton}
             </div>
 
@@ -2246,12 +2246,12 @@ export default class Exchange extends React.Component {
             <div className="col-3 p-1" style={{marginTop:9}}>
               DAI
             </div>
-            <div className="col-5 p-1" style={{marginTop:9,whiteSpace:"nowrap"}}>
+            <div className="col-4 p-1" style={{marginTop:9,whiteSpace:"nowrap"}}>
               <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
                 ${this.props.dollarDisplay(this.props.daiBalance)}
               </Scaler>
             </div>
-            <div className="col-2 p-1" style={{marginTop:8}}>
+            <div className="col-3 p-1" style={{marginTop:8}}>
               {sendDaiButton}
             </div>
           </div>
@@ -2270,12 +2270,12 @@ export default class Exchange extends React.Component {
             <div className="col-3 p-1" style={{marginTop:10}}>
               ETH
             </div>
-            <div className="col-5 p-1" style={{marginTop:10,whiteSpace:"nowrap"}}>
+            <div className="col-4 p-1" style={{marginTop:10,whiteSpace:"nowrap"}}>
               <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
                 ${this.props.dollarDisplay(this.props.ethBalance*this.props.ethprice)}
               </Scaler>
             </div>
-            <div className="col-2 p-1" style={{marginTop:8}}>
+            <div className="col-3 p-1" style={{marginTop:8}}>
               {sendEthButton}
             </div>
           </div>
@@ -2284,7 +2284,7 @@ export default class Exchange extends React.Component {
           { (window.location.hostname.indexOf("localhost") >= 0 || window.location.hostname.indexOf("wyre.xdai.io") >= 0) && (
             <div>
               <div className="content ops row">
-                <div className="col-10 p-1" style={{whiteSpace:"nowrap"}}>
+                <div className="col-9 p-1" style={{whiteSpace:"nowrap"}}>
                     {/*<div className="input-group">
                         <div className="input-group-prepend">
                             <div className="input-group-text">$</div>
@@ -2300,7 +2300,7 @@ export default class Exchange extends React.Component {
                             }
                         />
                     </div>*/}
-                    <div style={{padding: '0 20px', display: 'flex', alignItems: 'center', paddingTop: '15px',}}>
+                    <div className="wyre-slider" style={{padding: '0 20px', display: 'flex', alignItems: 'center', paddingTop: '15px',}}>
                     <InputRange
                         maxValue={25}
                         minValue={5}
@@ -2313,7 +2313,7 @@ export default class Exchange extends React.Component {
                     />
                     </div>
                 </div>
-                <div className="col-2 p-1" style={{marginTop:8}}>
+                <div className="col-3 p-1" style={{marginTop:8}}>
                   {fundByWyreButton}
                   <div className="wyre-sublabel--font-size" style={{
                       textAlign: 'center',

--- a/src/components/Exchange.js
+++ b/src/components/Exchange.js
@@ -2315,14 +2315,13 @@ export default class Exchange extends React.Component {
                 </div>
                 <div className="col-2 p-1" style={{marginTop:8}}>
                   {fundByWyreButton}
-                  <div style={{
+                  <div className="wyre-sublabel--font-size" style={{
                       textAlign: 'center',
                       letterSpacing: '.2px',
-                      fontSize: '12px',
                       color: '#7E7E7E',
                       marginTop: '5px',
                   }}>
-                    (Daily limit of $25)
+                    Daily Limit: $25
                   </div>
                 </div>
               </div>

--- a/src/components/Exchange.js
+++ b/src/components/Exchange.js
@@ -2034,7 +2034,7 @@ export default class Exchange extends React.Component {
 
     let fundByWyreButton = (
       <button
-        className="btn btn-large w-100"
+        className="btn btn-large w-100 wyre-button--font-size"
         disabled={buttonsDisabled}
         style={
             Object.assign({}, this.props.buttonStyle.secondary, {


### PR DESCRIPTION
- Improve limit sublabel under Wyre button responsive sizing.
- Change fund ETH by Wyre button text sizing responsive.
- Move Wyre slider labels down and prefix with class name.
- Make slider text labels non-selectable.
- Change Slider thumb button size for responsiveness.

**NOTE: this does not solve all the ui/ux tasks outlined in the issue. Those require some help from Wyre.**

Closes #116.