### PR TITLE
Return to SendToAddress when closing QRCode Scanner

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -775,9 +775,9 @@ changeAlert = (alert, hide=true) => {
     }, 2000);
   }
 };
-goBack(){
+goBack(view="main"){
   console.log("GO BACK")
-  this.changeView('main')
+  this.changeView(view)
   setTimeout(()=>{window.scrollTo(0,0)},60)
 }
 async parseBlocks(parseBlock,recentTxs,transactionsByAddress){

--- a/src/components/SendByScan.js
+++ b/src/components/SendByScan.js
@@ -105,7 +105,7 @@ class SendByScan extends Component {
   onClose = () => {
     console.log("SCAN CLOSE")
     this.stopRecording();
-    this.props.goBack();
+    this.props.goBack(this.props.returnState.goBackView);
   };
   componentDidMount(){
     interval = setInterval(this.loadMore.bind(this),750)

--- a/src/components/SendToAddress.js
+++ b/src/components/SendToAddress.js
@@ -284,7 +284,7 @@ export default class SendToAddress extends React.Component {
                   ref={(input) => { this.addressInput = input; }}
                        onChange={event => this.updateState('toAddress', event.target.value)} />
                 <div className="input-group-append" onClick={() => {
-                  this.props.openScanner({view:"send_to_address"})
+                  this.props.openScanner({view:"send_to_address",goBackView:"send_to_address"})
                 }}>
                   <span className="input-group-text" id="basic-addon2" style={this.props.buttonStyle.primary}>
                     <i style={{color:"#FFFFFF"}} className="fas fa-qrcode" />


### PR DESCRIPTION
I noticed that when you open sendToAddress, open the QR code scanner and then click close, it switches back to the main view. Instead it should (IMO at least) return to sendToAddress.

This PR fixes this.