### PR TITLE
Launch SendByScan as overlay

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -312,10 +312,11 @@ class App extends Component {
     })
   }
   openScanner(returnState){
-    this.setState({returnState:returnState,view:"send_by_scan"})
+    this.setState({returnState:returnState, scannerOpen: true})
   }
   returnToState(scannerState){
-    let updateState = Object.assign({scannerState:scannerState}, this.state.returnState);
+    let updateState = Object.assign({scannerState}, this.state.returnState);
+    updateState.scannerOpen = false
     updateState.returnState = false
     console.log("UPDATE FROM RETURN STATE",updateState)
     this.setState(updateState)
@@ -775,9 +776,10 @@ changeAlert = (alert, hide=true) => {
     }, 2000);
   }
 };
-goBack(){
+goBack(view="main"){
   console.log("GO BACK")
-  this.changeView('main')
+  this.changeView(view)
+  this.setState({scannerOpen: false})
   setTimeout(()=>{window.scrollTo(0,0)},60)
 }
 async parseBlocks(parseBlock,recentTxs,transactionsByAddress){
@@ -1333,10 +1335,25 @@ render() {
             )
           }
 
+          const sendByScan = (
+            <SendByScan
+              parseAndCleanPath={this.parseAndCleanPath.bind(this)}
+              returnToState={this.returnToState.bind(this)}
+              returnState={this.state.returnState}
+              mainStyle={mainStyle}
+              goBack={this.goBack.bind(this)}
+              changeView={this.changeView}
+              onError={(error) =>{
+                this.changeAlert("danger",error)
+              }}
+            />
+          )
+
           switch(view) {
             case 'main':
             return (
               <div>
+                {this.state.scannerOpen ? sendByScan : null}
                 <div className="main-card card w-100" style={{zIndex:1}}>
 
 
@@ -1385,6 +1402,7 @@ render() {
             case 'advanced':
             return (
               <div>
+                {this.state.scannerOpen ? sendByScan : null}
                 <div className="main-card card w-100" style={{zIndex:1}}>
 
                   <NavCard title={i18n.t('advance_title')} goBack={this.goBack.bind(this)}/>
@@ -1407,25 +1425,12 @@ render() {
                 />
               </div>
             )
-            case 'send_by_scan':
-            return (
-              <SendByScan
-                parseAndCleanPath={this.parseAndCleanPath.bind(this)}
-                returnToState={this.returnToState.bind(this)}
-                returnState={this.state.returnState}
-                mainStyle={mainStyle}
-                goBack={this.goBack.bind(this)}
-                changeView={this.changeView}
-                onError={(error) =>{
-                  this.changeAlert("danger",error)
-                }}
-              />
-            );
             case 'withdraw_from_private':
 
 
               return (
                 <div>
+                  {this.state.scannerOpen ? sendByScan : null}
                   <div className="send-to-address card w-100" style={{zIndex:1}}>
                     <NavCard title={i18n.t('withdraw')} goBack={this.goBack.bind(this)}/>
                     {defaultBalanceDisplay}
@@ -1455,6 +1460,7 @@ render() {
             case 'send_badge':
             return (
               <div>
+                {this.state.scannerOpen ? sendByScan : null}
                 <div className="send-to-address card w-100" style={{zIndex:1}}>
                   <NavCard title={this.state.badges[this.state.selectedBadge].name} titleLink={this.state.badges[this.state.selectedBadge].external_url} goBack={this.goBack.bind(this)}/>
                   <SendBadge
@@ -1486,6 +1492,7 @@ render() {
             case 'send_to_address':
             return (
               <div>
+                {this.state.scannerOpen ? sendByScan : null}
                 <div className="send-to-address card w-100" style={{zIndex:1}}>
                   <NavCard title={i18n.t('send_to_address_title')} goBack={this.goBack.bind(this)}/>
                   {defaultBalanceDisplay}
@@ -1518,6 +1525,7 @@ render() {
             case 'receipt':
             return (
               <div>
+                {this.state.scannerOpen ? sendByScan : null}
                 <div className="main-card card w-100" style={{zIndex:1}}>
 
                   <NavCard title={i18n.t('receipt_title')} goBack={this.goBack.bind(this)}/>
@@ -1550,6 +1558,7 @@ render() {
             case 'receive':
             return (
               <div>
+                {this.state.scannerOpen ? sendByScan : null}
                 <div className="main-card card w-100" style={{zIndex:1}}>
 
                   <NavCard title={i18n.t('receive_title')} goBack={this.goBack.bind(this)}/>
@@ -1583,6 +1592,7 @@ render() {
             case 'request_funds':
             return (
               <div>
+                {this.state.scannerOpen ? sendByScan : null}
                 <div className="main-card card w-100" style={{zIndex:1}}>
 
                   <NavCard title={i18n.t('request_funds_title')} goBack={this.goBack.bind(this)}/>
@@ -1619,6 +1629,7 @@ render() {
 
               return (
                 <div>
+                  {this.state.scannerOpen ? sendByScan : null}
                   <div className="main-card card w-100" style={{zIndex:1}}>
 
                     <NavCard title={url} goBack={this.goBack.bind(this)} />
@@ -1642,6 +1653,7 @@ render() {
             case 'share-link':
               return (
                 <div>
+                  {this.state.scannerOpen ? sendByScan : null}
                   <div className="main-card card w-100" style={{zIndex:1}}>
 
                     <NavCard title={'Share Link'} goBack={this.goBack.bind(this)} />
@@ -1662,6 +1674,7 @@ render() {
             case 'send_with_link':
             return (
               <div>
+                {this.state.scannerOpen ? sendByScan : null}
                 <div className="main-card card w-100" style={{zIndex:1}}>
 
                   <NavCard title={'Send with Link'} goBack={this.goBack.bind(this)} />
@@ -1717,6 +1730,7 @@ render() {
             case 'burn-wallet':
             return (
               <div>
+                {this.state.scannerOpen ? sendByScan : null}
                 <div className="main-card card w-100" style={{zIndex:1}}>
 
                   <NavCard title={"Burn Private Key"} goBack={this.goBack.bind(this)}/>
@@ -1751,6 +1765,7 @@ render() {
             case 'cash_out':
             return (
               <div>
+                {this.state.scannerOpen ? sendByScan : null}
                 <div className="main-card card w-100" style={{zIndex:1}}>
 
                   <NavCard title={"Cash Out"} goBack={this.goBack.bind(this)}/>
@@ -1773,6 +1788,7 @@ render() {
             case 'exchange':
             return (
               <div>
+                {this.state.scannerOpen ? sendByScan : null}
                 <div className="main-card card w-100" style={{zIndex:1}}>
 
                   <NavCard title={i18n.t('exchange_title')} goBack={this.goBack.bind(this)}/>
@@ -1817,6 +1833,7 @@ render() {
             case 'vendors':
             return (
               <div>
+                {this.state.scannerOpen ? sendByScan : null}
                 <div className="main-card card w-100" style={{zIndex:1}}>
 
                   <NavCard title={i18n.t('vendors')} goBack={this.goBack.bind(this)}/>

--- a/src/components/SendByScan.js
+++ b/src/components/SendByScan.js
@@ -5,6 +5,8 @@ import QrCode from 'qrcode-reader';
 import qrimage from '../qrcode.png';
 import RNMessageChannel from 'react-native-webview-messaging';
 import i18n from "../i18n";
+import Web3 from "web3";
+
 var Jimp = require("jimp");
 let interval
 class SendByScan extends Component {
@@ -77,17 +79,17 @@ class SendByScan extends Component {
       console.log("dataAfterColon:",dataAfterColon)
       if (dataAfterColon) {
         this.stopRecording();
-        console.log("RETURN STATE:",this.props.returnState)
-        if(this.props.returnState && this.props.returnState.view!="send_to_address"){
+        if (Web3.utils.isAddress(dataAfterColon)) {
+          console.log("RETURN STATE:",this.props.returnState)
           let returnState = this.props.parseAndCleanPath(dataAfterColon)
           this.props.returnToState(returnState)
-          console.log("return state",returnState)
-        }else{
-          this.props.changeView('reader')
-          setTimeout(()=>{
-            //maybe they just scanned an address?
-            window.location = "/"+dataAfterColon
-          },100)
+        } else {
+            // NOTE: Everything that is not a valid Ethereum address, we insert
+            // in the URL to see if the burner wallet can resolve it.
+            this.props.changeView("reader")
+            setTimeout(() => {
+                window.location = "/" +  dataAfterColon 
+            }, 100)
         }
       }
     }

--- a/src/components/SendToAddress.js
+++ b/src/components/SendToAddress.js
@@ -13,44 +13,29 @@ export default class SendToAddress extends React.Component {
   constructor(props) {
     super(props);
 
-
-
     console.log("!!!!!!!!!!!!!!!!!!!!!!!! window.location.search",window.location.search,parsed)
 
-    let startAmount = props.amount
-    if(props.scannerState) startAmount = props.scannerState.amount
-    if(!startAmount) {
-      startAmount = cookie.load('sendToStartAmount')
-    }else{
-      cookie.save('sendToStartAmount', startAmount, { path: '/', maxAge: 60 })
-    }
-    let startMessage= props.message
-    if(props.scannerState) startMessage = props.scannerState.message
-    if(!startMessage) {
-      startMessage = cookie.load('sendToStartMessage')
-    }else{
-      cookie.save('sendToStartMessage', startMessage, { path: '/', maxAge: 60 })
-    }
-
-    let extraMessage = props.extraMessage
-    if(props.scannerState) extraMessage = props.scannerState.extraMessage
-
-    let toAddress = ""
-    if(props.scannerState) toAddress = props.scannerState.toAddress
-    if(!toAddress) {
-      toAddress = cookie.load('sendToAddress')
-    }else{
-      cookie.save('sendToAddress', toAddress, { path: '/', maxAge: 60 })
+    let initialState;
+    if (props.scannerState) {
+      const { amount, message, extraMessage, toAddress } = props.scannerState
+      initialState = {
+        amount,
+        message,
+        extraMessage,
+        toAddress
+      }
+    } else {
+      const { amount, message, extraMessage } = props
+      initialState = {
+        amount: amount,
+        message: message,
+        extraMessage: extraMessage,
+        toAddress: ""
+      }
     }
 
-    let initialState = {
-      amount: startAmount,
-      message: startMessage,
-      toAddress: toAddress,
-      extraMessage: extraMessage,
-      fromEns: "",
-      canSend: false,
-    }
+    initialState.fromEns = ""
+    initialState.canSend = false
 
     let startingAmount = 0.15
     if(props.amount){
@@ -73,23 +58,17 @@ export default class SendToAddress extends React.Component {
     }
 
     this.state = initialState
-  //  console.log("SendToAddress constructor",this.state)
+    //console.log("SendToAddress constructor",this.state)
     window.history.pushState({},"", "/");
+  }
 
-
-
+  componentWillReceiveProps(newProps) {
+    if (this.props.scannerState !== newProps.scannerState) {
+        this.setState(Object.assign(this.state, newProps.scannerState))
+    }
   }
 
   updateState = async (key, value) => {
-    if(key=="amount"){
-      cookie.save('sendToStartAmount', value, { path: '/', maxAge: 60 })
-    }
-    else if(key=="message"){
-      cookie.save('sendToStartMessage', value, { path: '/', maxAge: 60 })
-    }
-    else if(key=="toAddress"){
-      cookie.save('sendToAddress', value, { path: '/', maxAge: 60 })
-    }
     this.setState({ [key]: value },()=>{
       this.setState({ canSend: this.canSend() },()=>{
         if(key!="message"){


### PR DESCRIPTION
This PR opens the `send_by_scan` view as an overlay using `z-index`. It allows the existing view to be rendered in the background so that inputs' values don't get lost. E.g. in the case of the `send_by_address` view, when a user types the `message` or the `amount` before opening the QR-code scanner to scan the address, those values remain and do not have to be written in the cookies anymore. The `scannerState` is delivered via props now.

I tried to test this change as much as possible. But as I don't know all the chases `SendByScan` can handle, I might have missed some.

I tested to scan:

- Scanning an Address
- Scanning a PK
- Scanning a Request QR code

and they all worked. 