### PR TITLE
Fix NaNd ago in History of RequestFunds

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1225,6 +1225,7 @@ render() {
                     <NavCard title={i18n.t('request_funds_title')} />
                     {defaultBalanceDisplay}
                     <RequestFunds
+                      block={block}
                       mainStyle={mainStyle}
                       buttonStyle={buttonStyle}
                       balance={balance}


### PR DESCRIPTION
On xdai.io right now when opening the RequestFunds page (notice "NaNd ago"):

![image](https://user-images.githubusercontent.com/2758453/56666008-6a472900-66ab-11e9-8c64-fb0133c95496.png)

After the fix:
<img width="741" alt="Screen Shot 2019-04-24 at 16 07 11" src="https://user-images.githubusercontent.com/2758453/56666028-74692780-66ab-11e9-919f-74ae016342e1.png">
