### PR TITLE
Fix SendToAddress button

### DIFF
--- a/src/components/SendToAddress.js
+++ b/src/components/SendToAddress.js
@@ -152,7 +152,8 @@ export default class SendToAddress extends React.Component {
         toAddress: resolvedAddress
       })
     }*/
-    return (this.state.toAddress && this.state.toAddress.length === 42 && (this.state.amount>0 || this.state.message))
+    const { toAddress, amount, message } = this.state;
+    return (toAddress && toAddress.length === 42 && (amount>0 || message))
   }
 
   scrollToBottom(){
@@ -335,7 +336,7 @@ export default class SendToAddress extends React.Component {
             />
           </Field>
         </Box>
-        <Button size={'large'} width={1} disabled={canSend} onClick={this.send}>
+        <Button size={'large'} width={1} disabled={!canSend} onClick={this.send}>
           Send
         </Button>
       </div>


### PR DESCRIPTION
Noticed that the send button on SendToAddress would always disable when I put in all my values. See how canSend was cast to string here: https://github.com/leapdao/burner-wallet/blame/8feaf5ff4a5922208514c5855b36b81daf5ed663/src/components/SendToAddress.js#L295

Big fan of the rimble-ui branch. Needs a rebase against master soon though! Otherwise it goes stale.