### PR TITLE
Rimbleify more components

### DIFF
--- a/src/components/Exchange.js
+++ b/src/components/Exchange.js
@@ -1193,20 +1193,13 @@ export default class Exchange extends React.Component {
             <div className="col-6 p-1" style={colStyle}>
               <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
               <div className="input-group">
-                <div className="input-group-prepend">
-                  <div className="input-group-text">$</div>
-                </div>
-                <input type="number" step="0.1" className="form-control" placeholder="0.00" value={this.state.amount}
-                       onChange={event => this.updateState('amount', event.target.value)} />
-                 <div className="input-group-append" onClick={() => {
-                    this.setState({amount: Math.floor(this.props.daiBalance*100)/100 },()=>{
-                      this.setState({ canSendDai: this.canSendDai(), canSendEth: this.canSendEth(), canSendXdai: this.canSendXdai() })
-                    })
-                 }}>
-                   <span className="input-group-text" id="basic-addon2" style={this.props.buttonStyle.secondary}>
-                     max
-                   </span>
-                 </div>
+                <Input
+                  width={1}
+                  type="number"
+                  step="0.1"
+                  placeholder="$0.00"
+                  value={this.state.amount}
+                  onChange={event => this.updateState('amount', event.target.value)} />
               </div>
               </Scaler>
             </div>
@@ -1278,20 +1271,13 @@ export default class Exchange extends React.Component {
             <div className="col-6 p-1" style={colStyle}>
               <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
               <div className="input-group">
-                <div className="input-group-prepend">
-                  <div className="input-group-text">$</div>
-                </div>
-                <input type="number" step="0.1" className="form-control" placeholder="0.00" value={this.state.amount}
-                       onChange={event => this.updateState('amount', event.target.value)} />
-                   <div className="input-group-append" onClick={() => {
-                      this.setState({amount: Math.floor((this.props.xdaiBalance-0.01)*100)/100 },()=>{
-                        this.setState({ canSendDai: this.canSendDai(), canSendEth: this.canSendEth(), canSendXdai: this.canSendXdai() })
-                      })
-                   }}>
-                     <span className="input-group-text" id="basic-addon2" style={this.props.buttonStyle.secondary}>
-                       max
-                     </span>
-                   </div>
+                <Input
+                  width={1}
+                  type="number"
+                  step="0.1"
+                  placeholder="$0.00"
+                  value={this.state.amount}
+                  onChange={event => this.updateState('amount', event.target.value)} />
               </div>
               </Scaler>
             </div>
@@ -1461,48 +1447,13 @@ export default class Exchange extends React.Component {
             <div className="col-6 p-1" style={colStyle}>
               <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
               <div className="input-group">
-                <div className="input-group-prepend">
-                  <div className="input-group-text">$</div>
-                </div>
-                <input type="number" step="0.1" className="form-control" placeholder="0.00" value={this.state.amount}
-                       onChange={event => this.updateState('amount', event.target.value)} />
-                 <div className="input-group-append" onClick={() => {
-
-                   console.log("Getting gas price...")
-                   axios.get("https://ethgasstation.info/json/ethgasAPI.json", { crossdomain: true })
-                   .catch((err)=>{
-                     console.log("Error getting gas price",err)
-                   })
-                   .then((response)=>{
-                     if(response && response.data.average>0&&response.data.average<200){
-                       response.data.average=response.data.average + (response.data.average*GASBOOSTPRICE)
-                       let gwei = Math.round(response.data.average*100)/1000
-
-                       console.log(gwei)
-
-
-                       let IDKAMOUNTTOLEAVE = gwei*(1111000000*2) * 201000 // idk maybe enough for a couple transactions?
-
-                       console.log("let's leave ",IDKAMOUNTTOLEAVE,this.props.ethBalance)
-
-                       let gasInEth = this.props.web3.utils.fromWei(""+IDKAMOUNTTOLEAVE,'ether')
-                       console.log("gasInEth",gasInEth)
-
-                       let adjustedEthBalance = (parseFloat(this.props.ethBalance) - parseFloat(gasInEth))
-                       console.log(adjustedEthBalance)
-
-                       this.setState({amount: Math.floor(this.props.ethprice*adjustedEthBalance*100)/100 },()=>{
-                         this.setState({ canSendDai: this.canSendDai(), canSendEth: this.canSendEth(), canSendXdai: this.canSendXdai() })
-                       })
-
-                     }
-                   })
-
-                 }}>
-                   <span className="input-group-text" id="basic-addon2" style={this.props.buttonStyle.secondary}>
-                     max
-                   </span>
-                 </div>
+                <Input
+                  width={1}
+                  type="number"
+                  step="0.1"
+                  placeholder="$0.00"
+                  value={this.state.amount}
+                  onChange={event => this.updateState('amount', event.target.value)} />
               </div>
               </Scaler>
             </div>
@@ -1628,20 +1579,13 @@ export default class Exchange extends React.Component {
             <div className="col-6 p-1" style={colStyle}>
               <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
               <div className="input-group">
-                <div className="input-group-prepend">
-                  <div className="input-group-text">$</div>
-                </div>
-                <input type="number" step="0.1" className="form-control" placeholder="0.00" value={this.state.amount}
-                       onChange={event => this.updateState('amount', event.target.value)} />
-               <div className="input-group-append" onClick={() => {
-                  this.setState({amount: Math.floor((this.props.daiBalance)*100)/100 },()=>{
-                    this.setState({ canSendDai: this.canSendDai(), canSendEth: this.canSendEth(), canSendXdai: this.canSendXdai() })
-                  })
-               }}>
-                 <span className="input-group-text" id="basic-addon2" style={this.props.buttonStyle.secondary}>
-                   max
-                 </span>
-               </div>
+                <Input
+                  width={1}
+                  type="number"
+                  step="0.1"
+                  placeholder="$0.00"
+                  value={this.state.amount}
+                  onChange={event => this.updateState('amount', event.target.value)} />
               </div>
               </Scaler>
             </div>

--- a/src/components/Exchange.js
+++ b/src/components/Exchange.js
@@ -1217,8 +1217,8 @@ export default class Exchange extends React.Component {
             </div>
             <div className="col-3 p-1">
 
-              <button className="btn btn-large w-100"  disabled={buttonsDisabled}
-                style={this.props.buttonStyle.primary}
+              <Button
+                disabled={buttonsDisabled}
                 onClick={()=>{
                 console.log("AMOUNT:",this.state.amount,"DAI BALANCE:",this.props.daiBalance)
 
@@ -1249,7 +1249,7 @@ export default class Exchange extends React.Component {
                 <Scaler config={{startZoomAt:600,origin:"10% 50%"}}>
                   <i className="fas fa-arrow-up" /> Send
                 </Scaler>
-              </button>
+              </Button>
 
             </div>
           </div>
@@ -1301,7 +1301,7 @@ export default class Exchange extends React.Component {
               </Scaler>
             </div>
             <div className="col-3 p-1">
-              <button className="btn btn-large w-100"  disabled={buttonsDisabled} style={this.props.buttonStyle.primary} onClick={()=>{
+              <Button disabled={buttonsDisabled} onClick={async ()=>{
                 console.log("AMOUNT:",this.state.amount,"DAI BALANCE:",this.props.daiBalance)
                 this.setState({
                   daiToXdaiMode:"withdrawing",
@@ -1396,7 +1396,7 @@ export default class Exchange extends React.Component {
                 <Scaler config={{startZoomAt:600,origin:"10% 50%"}}>
                   <i className="fas fa-arrow-down" /> Send
                 </Scaler>
-              </button>
+              </Button>
 
             </div>
           </div>
@@ -1512,7 +1512,7 @@ export default class Exchange extends React.Component {
               </Scaler>
             </div>
             <div className="col-3 p-1">
-              <button className="btn btn-large w-100" disabled={buttonsDisabled} style={this.props.buttonStyle.primary} onClick={async ()=>{
+              <Button disabled={buttonsDisabled} onClick={async ()=>{
 
                 console.log("Using uniswap exchange to move ETH to DAI")
 
@@ -1588,7 +1588,7 @@ export default class Exchange extends React.Component {
                 <Scaler config={{startZoomAt:600,origin:"10% 50%"}}>
                   <i className="fas fa-arrow-up" /> Send
                 </Scaler>
-              </button>
+              </Button>
 
             </div>
           </div>
@@ -1651,7 +1651,7 @@ export default class Exchange extends React.Component {
               </Scaler>
             </div>
             <div className="col-3 p-1">
-              <button className="btn btn-large w-100" disabled={buttonsDisabled} style={this.props.buttonStyle.primary} onClick={async ()=>{
+              <Button disabled={buttonsDisabled} onClick={async ()=>{
 
                 console.log("Using uniswap exchange to move DAI to ETH")
 
@@ -1928,7 +1928,7 @@ export default class Exchange extends React.Component {
                 <Scaler config={{startZoomAt:600,origin:"10% 50%"}}>
                   <i className="fas fa-arrow-down" /> Send
                 </Scaler>
-              </button>
+              </Button>
             </div>
           </div>
         )

--- a/src/components/SendBadge.js
+++ b/src/components/SendBadge.js
@@ -7,6 +7,13 @@ import Blockies from 'react-blockies';
 import { scroller } from 'react-scroll'
 import Badge from './Badge';
 import i18n from '../i18n';
+import {
+  Box,
+  Field,
+  Input,
+  Button,
+  OutlineButton
+} from "rimble-ui";
 
 export default class SendBadge extends React.Component {
   constructor(props) {
@@ -125,47 +132,35 @@ export default class SendBadge extends React.Component {
     var percent = (h[st]||b[st]) / ((h[sh]||b[sh]) - h.clientHeight) * 100;
     let angle = Math.round(-28 + 75*percent/100)
     return (
-      <div>
-        <div className="content row" onClick={()=>{
-          window.open(this.props.badge.external_url,'_blank')
-        }}>
-            <Badge large={true} angle={angle} key={"b"+this.props.badge.id} id={this.props.badge.id} image={this.props.badge.image}/>
-        </div>
-        <div style={{fontSize:14,width:"100%",textAlign:"center"}}>
-          {this.props.badge.description}
-        </div>
+      <Box mb={4}>
+        <Badge
+          large={true}
+          angle={angle}
+          key={this.props.badge.id}
+          id={this.props.badge.id}
+          image={this.props.badge.image} />
         <Ruler />
-        <div className="content row">
-          <div className="form-group w-100">
-            <div className="form-group w-100">
-              <label htmlFor="amount_input">{i18n.t('send_to_address.to_address')}</label>
-              <div className="input-group">
-                <input type="text" className="form-control" placeholder="0x..." value={this.state.toAddress}
-                  ref={(input) => { this.addressInput = input; }}
-                       onChange={event => this.updateState('toAddress', event.target.value)} />
-                <div className="input-group-append" onClick={() => this.props.openScanner({view:'send_badge'})}>
-                  <span className="input-group-text" id="basic-addon2" style={this.props.buttonStyle.primary}>
-                    <i style={{color:"#FFFFFF"}} className="fas fa-qrcode" />
-                  </span>
-                </div>
-              </div>
-            </div>
-
-            <div>  { this.state.toAddress && this.state.toAddress.length==42 &&
-              <CopyToClipboard text={toAddress.toLowerCase()}>
-                <div style={{cursor:"pointer"}} onClick={() => this.props.changeAlert({type: 'success', message: toAddress.toLowerCase()+' copied to clipboard'})}>
-                  <div style={{opacity:0.33}}>{this.state.fromEns}</div>
-                  <Blockies seed={toAddress.toLowerCase()} scale={10}/>
-                </div>
-              </CopyToClipboard>
-            }</div>
-          </div>
-          <button name="theVeryBottom" className={`btn btn-lg w-100 ${canSend ? '' : 'disabled'}`} style={this.props.buttonStyle.primary}
-                  onClick={this.send}>
-            Send
-          </button>
-        </div>
-      </div>
+        <Field mb={3} label="To Address">
+          <Input
+            width={1}
+            type="text"
+            placeholder="0x..."
+            value={toAddress}
+            ref={(input) => { this.addressInput = input; }}
+            onChange={event => this.updateState('toAddress', event.target.value)} />
+          <OutlineButton icon={'CenterFocusWeak'} mb={4} width={1} onClick={() => {this.props.openScanner({view:"send_badge", goBackView:"send_badge"})}}>
+            Scan QR Code
+          </OutlineButton>
+        </Field>
+        <Button
+          size="large"
+          width={1}
+          name="theVeryBottom"
+          disabled={!canSend}
+          onClick={this.send}>
+          Send
+        </Button>
+      </Box>
     )
   }
 }

--- a/src/components/SendBadge.js
+++ b/src/components/SendBadge.js
@@ -139,6 +139,9 @@ export default class SendBadge extends React.Component {
           key={this.props.badge.id}
           id={this.props.badge.id}
           image={this.props.badge.image} />
+          onClick={()=>{
+            window.open(this.props.badge.external_url,'_blank')
+          }}
         <Ruler />
         <Field mb={3} label="To Address">
           <Input
@@ -148,7 +151,7 @@ export default class SendBadge extends React.Component {
             value={toAddress}
             ref={(input) => { this.addressInput = input; }}
             onChange={event => this.updateState('toAddress', event.target.value)} />
-          <OutlineButton icon={'CenterFocusWeak'} mb={4} width={1} onClick={() => {this.props.openScanner({view:"send_badge", goBackView:"send_badge"})}}>
+          <OutlineButton icon={'CenterFocusWeak'} mb={4} width={1} onClick={() => {this.props.openScanner({view:"send_badge"})}}>
             Scan QR Code
           </OutlineButton>
         </Field>

--- a/src/components/WithdrawFromPrivate.js
+++ b/src/components/WithdrawFromPrivate.js
@@ -5,6 +5,10 @@ import { Scaler } from "dapparatus";
 import Balance from "./Balance";
 import Blockies from 'react-blockies';
 import i18n from '../i18n';
+import {
+  Button,
+  Input
+} from 'rimble-ui'
 
 let pollInterval
 let metaReceiptTracker = {}
@@ -172,7 +176,11 @@ export default class SendToAddress extends React.Component {
             <div className="form-group w-100">
               <div className="form-group w-100">
                 <label htmlFor="amount_input">{i18n.t('withdraw_from_private.from_address')}</label>
-                <input type="text" className="form-control" placeholder="0x..." value={fromAddress} />
+                <Input
+                  width={1}
+                  type="text"
+                  placeholder="0x..."
+                  value={fromAddress} />
               </div>
 
               <div className="content bridge row">
@@ -190,18 +198,22 @@ export default class SendToAddress extends React.Component {
 
               <label htmlFor="amount_input">{i18n.t('withdraw_from_private.amount')}</label>
               <div className="input-group">
-                <div className="input-group-prepend">
-                  <div className="input-group-text">$</div>
-                </div>
-                <input type="number" className="form-control" placeholder="0.00" value={this.state.amount}
-                       onChange={event => this.updateState('amount', event.target.value)} />
+                <Input 
+                  width={1}
+                  type="number"
+                  placeholder="$0.00"
+                  value={this.state.amount}
+                  onChange={event => this.updateState('amount', event.target.value)} />
               </div>
               {products}
             </div>
-            <button style={this.props.buttonStyle.primary} className={`btn btn-success btn-lg w-100 ${canWithdraw ? '' : 'disabled'}`}
-                    onClick={this.withdraw}>
+            <Button 
+              size={'large'}
+              width={1}
+              disabled={!canWithdraw}
+              onClick={this.withdraw}>
               {i18n.t('withdraw_from_private.withdraw')}
-            </button>
+            </Button>
           </div>
       </div>
     )


### PR DESCRIPTION
I use rimble-ui in the following views now:

- For all togglable inputs and buttons of the Exchange.js view
- For the WithdrawFromPrivateKey view

Note that I've removed a fair amount of features with this PR. The "max"-send button is not there anymore. The dollar sign prepended to the input isn't there anymore.

Not sure how we want to handle this. Rimble-ui currently doesn't support preprends and appends to the `<Input />` component. At least it's not in their [docs](https://consensys.github.io/rimble-ui/?path=/story/components-form-inputs--documentation). Should we open an issue on their repo?

Not sure if these changes are particularly useful therefore :/
Sent a PR anyways. You never know 🤷‍♂ 