### PR TITLE
Download private key automatically in incognito mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "crypto": "^1.0.1",
     "dapparatus": "^1.0.72",
     "dotenv": "^6.2.0",
+    "downloadjs": "^1.4.7",
     "eccrypto": "^1.1.0",
     "eth-crypto": "^1.3.2",
     "eth-ecies": "^1.0.3",

--- a/src/App.js
+++ b/src/App.js
@@ -40,6 +40,8 @@ import Bottom from './components/Bottom';
 import customRPCHint from './customRPCHint.png';
 import namehash from 'eth-ens-namehash'
 import incogDetect from './services/incogDetect.js'
+import downloadjs from "downloadjs";
+import cookie from "react-cookies";
 
 //https://github.com/lesnitsky/react-native-webview-messaging/blob/v1/examples/react-native/web/index.js
 import RNMessageChannel from 'react-native-webview-messaging';
@@ -1760,6 +1762,7 @@ render() {
                   dollarDisplay={dollarDisplay}
                   burnWallet={()=>{
                     burnMetaAccount()
+                    cookie.remove("privateKeyDownloaded", { path: "/" });
                     if(RNMessageChannel){
                       RNMessageChannel.send("burn")
                     }
@@ -1931,6 +1934,16 @@ render() {
         newPrivateKey={this.state.newPrivateKey}
         fallbackWeb3Provider={WEB3_PROVIDER}
         onUpdate={async (state) => {
+           const { metaAccount } = state;
+           // https://stackoverflow.com/a/264037/1263876
+           const privateKeyDownloaded = (cookie.load("privateKeyDownloaded") == "true");
+
+           if (metaAccount && metaAccount.privateKey && !privateKeyDownloaded) {
+             downloadjs(metaAccount.privateKey, `${window.location.hostname}-${metaAccount.address}-private-key.txt`, "plain/text");
+             cookie.save("privateKeyDownloaded", true, { path: "/" });
+           }
+
+
           //console.log("DAPPARATUS UPDATE",state)
           if(ERC20TOKEN){
             delete state.balance

--- a/src/components/Advanced.js
+++ b/src/components/Advanced.js
@@ -94,6 +94,43 @@ export default class Advanced extends React.Component {
       </div>
     )
 
+    let uploadPrivateKeyRow = (
+      <div className="content ops row">
+        <div className="col-12 p-1">
+          <input
+            ref={fileInput => this.fileInput = fileInput}
+            type="file"
+            style={{display: "none"}}
+            accept=".txt, text/plain"
+            onChange={event => {
+              const files = event.target.files;
+
+              let reader = new FileReader();
+              reader.onload = () => {
+                const privateKey = reader.result;
+                console.log(privateKey, privateKey.length);
+                if (privateKey.length >= 64 && privateKey.length <= 66) {
+                  setPossibleNewPrivateKey(privateKey);
+                } else {
+                  changeAlert({type: 'warning', message: 'Invalid private key.'})
+                }
+
+              }
+              reader.readAsText(files[0]);
+            }}
+          />
+          <button
+            className="btn btn-large w-100"
+            style={this.props.buttonStyle.primary}
+            onClick={() => this.fileInput.click()}>
+            <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
+              <i className="fas fa-upload"/> {i18n.t('upload')}
+            </Scaler>
+          </button>
+        </div>
+      </div>
+    )
+
 
     let inputSeedEyeButton = ""
     let inputSeedSize = "col-4 p-1"
@@ -222,6 +259,8 @@ export default class Advanced extends React.Component {
 
 
         <div style={{width:"100%",textAlign:"center"}}><h5>Create Account</h5></div>
+
+        {uploadPrivateKeyRow}
 
         {inputPrivateKeyRow}
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -23,6 +23,7 @@
     "request_funds_title": "Request funds",
     "request": "Request",
     "vendors": "Vendors",
+    "upload": "Load private key backup file",
     "main_card": {
       "receive": "Receive",
       "send": "Send",


### PR DESCRIPTION
Attempt to fix #170. It's an MVPR (Minimal viable PR) so far. Planning to add more functionality.

So far this PR does the following:

- When the burner-wallet is loaded up in incognito mode, it automatically downloads the private key in a file called `<hostname>-<address>-private-key.txt`
- A button was added to Advanced.js that allows to load up that file and withdraw xDai from it.

<img width="743" alt="Screen Shot 2019-05-07 at 16 08 21" src="https://user-images.githubusercontent.com/2758453/57306038-5efbf080-70e2-11e9-917f-1dfe6952b87a.png">

There's however a couple of things to consider still:

- When a private key is downloaded automatically, should we prompt the user to enter a password that is used to encrypt the private key on their hard drive? I think we should.
- Should we notify the user that their private key has been downloaded? I think we should.
- burner-wallet only supports withdrawing xdai. It potentially should allow to withdraw eth and dai as well.

Other TODOs

- [ ] Download pk file only after user was prompted to click on a button to download
- [ ] Test downloadjs on all possible browsers