### PR TITLE
fix: error converting small amounts of DAI to ETH

### DIFF
--- a/src/components/Exchange.js
+++ b/src/components/Exchange.js
@@ -1667,8 +1667,8 @@ export default class Exchange extends React.Component {
 
                 let output = await uniswapContract.methods.getEthToTokenOutputPrice(amountOfDai).call()
                 output = parseFloat(output)
-                output = output - (output*0.0333)
-                console.log("Expected amount of ETH: ",output,webToUse.utils.fromWei(""+Math.round(output),'ether'))
+                output = Math.round(output - (output*0.0333))
+                console.log("Expected amount of ETH: ",output,webToUse.utils.fromWei(""+ output,'ether'))
 
                 let currentBlockNumber = await webToUse.eth.getBlockNumber()
                 let currentBlock = await webToUse.eth.getBlock(currentBlockNumber)


### PR DESCRIPTION
**To reproduce:**
try to use `DAI to ETH` exchange with some small amount, like 0.01. You will get an error from `fromWei`

![image](https://user-images.githubusercontent.com/163447/58485428-b5ea6800-816c-11e9-92a8-f2840ab25da8.png)


Root cause: estimated amount of wei wasn't properly rounded.