### PR TITLE
URGENT: Update burner-core, fixing key saving bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@burner-wallet/assets": "0.0.1",
-    "@burner-wallet/core": "0.0.4",
+    "@burner-wallet/core": "0.0.5",
     "autolinker": "^2.2.1",
     "axios": "^0.18.0",
     "base64url": "^3.0.1",


### PR DESCRIPTION
There was a typo in burner core that can lead to loss of private keys. The typo has been fixed, so this pushes burner-wallet to the newest version of burner-core.

https://github.com/austintgriffith/burner-core/commit/63465b062a7ec64ea7be44964deb08997cf2d0e9