### PR TITLE
fix: prevent page reload when scanning QR codes (#200)

### DIFF
--- a/src/components/SendByScan.js
+++ b/src/components/SendByScan.js
@@ -102,11 +102,9 @@ class SendByScan extends Component {
           this.props.returnToState(returnState)
           console.log("return state",returnState)
         }else{
-          this.props.changeView('reader')
-          setTimeout(()=>{
-            //maybe they just scanned an address?
-            window.location = "/"+dataAfterColon
-          },100)
+          // Parse scanned data and update state without page reload
+          let returnState = this.props.parseAndCleanPath(dataAfterColon)
+          this.props.returnToState(returnState)
         }
       }
     }

--- a/src/components/SendByScan.js
+++ b/src/components/SendByScan.js
@@ -105,6 +105,7 @@ class SendByScan extends Component {
           // Parse scanned data and update state without page reload
           let returnState = this.props.parseAndCleanPath(dataAfterColon)
           this.props.returnToState(returnState)
+          this.props.changeView('send_to_address')
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes #200 — prevents full page reload when scanning QR codes in SendByScan component.

## Changes

**File:** `src/components/SendByScan.js`

**Before:**
```javascript
this.props.changeView('reader')
setTimeout(()=>{
  //maybe they just scanned an address?
  window.location = "/"+dataAfterColon
},100)
```

**After:**
```javascript
// Parse scanned data and update state without page reload
let returnState = this.props.parseAndCleanPath(dataAfterColon)
this.props.returnToState(returnState)
```

## How it works

Instead of forcing a full page reload via `window.location`, the fix uses the existing `parseAndCleanPath()` and `returnToState()` methods to handle scanned data. This:

1. Parses the scanned QR code data into a state object
2. Updates the app state via `returnToState()` (which calls `setState`)
3. Preserves the user's session, scroll position, and form data

## Testing

- Scan a private key → should load wallet without reload
- Scan a public key → should navigate to send view without reload
- Scan a payment request → should populate send form without reload
- Paper wallet initialization should still work

Fixes #200