### PR TITLE
feat: introduce dependency security process with Dependabot (#205)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Dependabot configuration for automated dependency updates
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    versioning-strategy: increase
+    labels:
+      - "dependencies"
+      - "security"
+    reviewers: []
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+## Reporting Vulnerabilities
+
+If you discover a security vulnerability in the Burner Wallet, please do **not** open a public issue. Instead, report it privately to the maintainers.
+
+## Dependency Management
+
+### Automated Updates
+This repository uses **Dependabot** to automatically monitor and update dependencies. Dependabot will open pull requests when:
+- A new version of a dependency is available
+- A security vulnerability is disclosed for a dependency
+
+### Lockfile
+Always commit `package-lock.json` or `yarn.lock` to pin exact dependency versions. This prevents supply-chain attacks via malicious patch versions (e.g., the 2018 event-stream incident).
+
+### Review Process
+- Review all Dependabot PRs within 7 days
+- For critical security patches, merge within 24 hours
+- Run `npm audit` or `yarn audit` before each release
+- Prefer exact versions (`1.2.3`) or tilde ranges (`~1.2.3`) over caret ranges (`^1.2.3`) for production-critical dependencies
+
+## Supported Versions
+Only the latest `master` branch is actively supported with security updates.


### PR DESCRIPTION
## Summary

Introduced a dependency security process as requested in issue #205, replacing the manual/vulnerable approach with automated monitoring.

### Changes
- Created `SECURITY.md` documenting:
  - Vulnerability reporting process
  - Dependency management guidelines
  - Lockfile and version pinning policy
  - Review timelines for security patches
- Configured `.github/dependabot.yml` for **automated weekly npm updates**
  - Dependabot is free and built into GitHub (vs. Greenkeeper which requires third-party access)
  - Opens PRs with dependency bumps, including security patches
  - Labels PRs with `dependencies` and `security` for easy triage

### Why Dependabot over Greenkeeper
- Built into GitHub — no third-party SaaS required
- Automatically catches security vulnerabilities (CVE alerts)
- Same automated PR workflow

### Next Steps (for maintainer)
- Enable Dependabot in repo Settings → Security → Dependabot alerts
- Run `npm audit fix` to address the 126 existing vulnerabilities
- Consider locking critical deps to exact versions in package.json

Closes #205

/claim