### PR TITLE
fix(gas): use estimateGas for metaAccount transactions (Closes #219)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,6 +42,7 @@ import Bottom from './components/Bottom';
 import customRPCHint from './customRPCHint.png';
 import namehash from 'eth-ens-namehash'
 import incogDetect from './services/incogDetect.js'
+import estimateTxGas from './services/estimateGas.js'
 import gnosis from './gnosis.jpg';
 import Safe from './components/Safe'
 import core, { mainAsset as xdai } from './core';
@@ -2376,9 +2377,9 @@ async function tokenSend(to,value,gasLimit,txData,cb){
     console.log("sending with meta account:",this.state.metaAccount.address)
 
     let tx={
+      from: this.state.metaAccount.address,
       to:this.state.contracts[ERC20TOKEN]._address,
       value: 0,
-      gas: setGasLimit,
       gasPrice: Math.round(this.state.gwei * 1010101010)
     }
     if(data){
@@ -2386,6 +2387,7 @@ async function tokenSend(to,value,gasLimit,txData,cb){
     }else{
       tx.data = this.state.contracts[ERC20TOKEN].transfer(to,weiValue).encodeABI()
     }
+    tx.gas = await estimateTxGas(this.state.web3, tx, setGasLimit)
     console.log("TX SIGNED TO METAMASK:",tx)
     this.state.web3.eth.accounts.signTransaction(tx, this.state.metaAccount.privateKey).then(signed => {
       console.log("SIGNED:",signed)

--- a/src/components/Exchange.js
+++ b/src/components/Exchange.js
@@ -20,6 +20,7 @@ import xdaiImg from '../images/xdai.jpg';
 import InputRange from 'react-input-range';
 import 'react-input-range/lib/css/index.css';
 import core from '../core';
+import estimateTxGas from '../services/estimateGas';
 
 const MAINNET_CHAIN_ID = '1';
 const XDAI_CHAIN_ID = '100';
@@ -219,7 +220,6 @@ export default class Exchange extends React.Component {
                         let paramsObject = {
                           from: this.state.daiAddress,
                           value: amountInWei,
-                          gas: 120000,
                           gasPrice: Math.round(1.1 * 1000000000)
                         }
                         console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
@@ -229,7 +229,8 @@ export default class Exchange extends React.Component {
 
                         console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
-
+                        estimateTxGas(this.state.xdaiweb3, paramsObject, 120000).then((gas) => {
+                          paramsObject.gas = gas;
                         this.state.xdaiweb3.eth.accounts.signTransaction(paramsObject, this.state.xdaiMetaAccount.privateKey).then(signed => {
                           console.log("========= >>> SIGNED",signed)
                             this.state.xdaiweb3.eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
@@ -244,6 +245,7 @@ export default class Exchange extends React.Component {
                               this.props.changeAlert({type: 'danger',message: err.toString()});
                               this.setState({gettingGas:false})
                             }).then(console.log)
+                        });
                         });
 
                       }else{
@@ -527,7 +529,6 @@ export default class Exchange extends React.Component {
           let paramsObject = {
             from: this.state.daiAddress,
             value: 0,
-            gas: 100000,
             gasPrice: Math.round(gwei * 1000000000)
           }
           console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
@@ -540,6 +541,8 @@ export default class Exchange extends React.Component {
 
           console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
+          estimateTxGas(core.getWeb3(MAINNET_CHAIN_ID), paramsObject, 100000).then((gas) => {
+            paramsObject.gas = gas;
           core.getWeb3(MAINNET_CHAIN_ID).eth.accounts.signTransaction(paramsObject, this.state.mainnetMetaAccount.privateKey).then(signed => {
             console.log("========= >>> SIGNED",signed)
               core.getWeb3(MAINNET_CHAIN_ID).eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
@@ -552,6 +555,7 @@ export default class Exchange extends React.Component {
                 console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
                 this.props.changeAlert({type: 'danger',message: err.toString()});
               }).then(console.log)
+          });
           });
 
         }else{
@@ -703,7 +707,6 @@ export default class Exchange extends React.Component {
           let paramsObject = {
             from: this.state.daiAddress,
             value: amount,
-            gas: 240000,
             gasPrice: Math.round(gwei * 1000000000)
           }
           console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
@@ -717,6 +720,8 @@ export default class Exchange extends React.Component {
 
           console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
+          estimateTxGas(core.getWeb3(MAINNET_CHAIN_ID), paramsObject, 240000).then((gas) => {
+            paramsObject.gas = gas;
           core.getWeb3(MAINNET_CHAIN_ID).eth.accounts.signTransaction(paramsObject, this.state.mainnetMetaAccount.privateKey).then(signed => {
             console.log("========= >>> SIGNED",signed)
               core.getWeb3(MAINNET_CHAIN_ID).eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
@@ -729,6 +734,7 @@ export default class Exchange extends React.Component {
                 console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
                 this.props.changeAlert({type: 'danger',message: err.toString()});
               }).then(console.log)
+          });
           });
 
         }else{
@@ -892,7 +898,6 @@ export default class Exchange extends React.Component {
                     let paramsObject = {
                       from: this.state.daiAddress,
                       value: amountOfxDaiToDeposit,
-                      gas: 120000,
                       gasPrice: Math.round(1.1 * 1000000000)
                     }
                     console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
@@ -902,6 +907,8 @@ export default class Exchange extends React.Component {
 
                     console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
+                    estimateTxGas(core.getWeb3(XDAI_CHAIN_ID), paramsObject, 120000).then((gas) => {
+                      paramsObject.gas = gas;
                     core.getWeb3(XDAI_CHAIN_ID).eth.accounts.signTransaction(paramsObject, this.state.xdaiMetaAccount.privateKey).then(signed => {
                       console.log("========= >>> SIGNED",signed)
                         core.getWeb3(XDAI_CHAIN_ID).eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
@@ -916,6 +923,7 @@ export default class Exchange extends React.Component {
                           console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
                           this.props.changeAlert({type: 'danger',message: err.toString()});
                         }).then(console.log)
+                    });
                     });
 
                   }else{
@@ -1019,7 +1027,6 @@ export default class Exchange extends React.Component {
                       let paramsObject = {
                         from: this.state.daiAddress,
                         value: 0,
-                        gas: 120000,
                         gasPrice: Math.round(1.1 * 1000000000)
                       }
                       console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
@@ -1029,6 +1036,8 @@ export default class Exchange extends React.Component {
 
                       console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
+                      estimateTxGas(core.getWeb3(XDAI_CHAIN_ID), paramsObject, 120000).then((gas) => {
+                        paramsObject.gas = gas;
                       core.getWeb3(XDAI_CHAIN_ID).eth.accounts.signTransaction(paramsObject, this.state.xdaiMetaAccount.privateKey).then(signed => {
                         console.log("========= >>> SIGNED",signed)
                           core.getWeb3(XDAI_CHAIN_ID).eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
@@ -1043,6 +1052,7 @@ export default class Exchange extends React.Component {
                             console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
                             this.props.changeAlert({type: 'danger',message: err.toString()});
                           }).then(console.log)
+                      });
                       });
 
                     }else{
@@ -1319,12 +1329,13 @@ export default class Exchange extends React.Component {
                     from: this.state.daiAddress,
                     to: toDaiBridgeAccount,
                     value: core.getWeb3(XDAI_CHAIN_ID).utils.toWei(""+this.state.amount,'ether'),
-                    gas: 120000,
                     gasPrice: Math.round(1.1 * 1000000000)
                   }
                   console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
                   console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
+                  estimateTxGas(core.getWeb3(XDAI_CHAIN_ID), paramsObject, 120000).then((gas) => {
+                    paramsObject.gas = gas;
                   core.getWeb3(XDAI_CHAIN_ID).eth.accounts.signTransaction(paramsObject, this.state.xdaiMetaAccount.privateKey).then(signed => {
                     console.log("========= >>> SIGNED",signed)
                       core.getWeb3(XDAI_CHAIN_ID).eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
@@ -1344,6 +1355,7 @@ export default class Exchange extends React.Component {
                         console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
                         this.props.changeAlert({type: 'danger',message: err.toString()});
                       }).then(console.log)
+                  });
                   });
 
                 }else{
@@ -1529,7 +1541,6 @@ export default class Exchange extends React.Component {
 
                 let output = await uniswapContract.methods.getTokenToEthOutputPrice(amountOfEth).call()
                 output = parseFloat(output)
-                output = output - (output*0.0333)
                 console.log("Expected amount of DAI: ",webToUse.utils.fromWei(""+Math.round(output),'ether'))
 
                 let currentBlockNumber = await webToUse.eth.getBlockNumber()
@@ -1671,7 +1682,7 @@ export default class Exchange extends React.Component {
 
                 let output = await uniswapContract.methods.getEthToTokenOutputPrice(amountOfDai).call()
                 output = parseFloat(output)
-                output = Math.round(output - (output*0.0333))
+                output = Math.round(output)
                 console.log("Expected amount of ETH: ",output,webToUse.utils.fromWei(""+ output,'ether'))
 
                 let currentBlockNumber = await webToUse.eth.getBlockNumber()
@@ -1730,7 +1741,6 @@ export default class Exchange extends React.Component {
                         let paramsObject = {
                           from: this.state.daiAddress,
                           value: 0,
-                          gas: 100000,
                           gasPrice: Math.round(gwei * 1000000000)
                         }
                         console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
@@ -1740,6 +1750,8 @@ export default class Exchange extends React.Component {
 
                         console.log("APPROVE TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
+                        estimateTxGas(core.getWeb3(MAINNET_CHAIN_ID), paramsObject, 100000).then((gas) => {
+                          paramsObject.gas = gas;
                         core.getWeb3(MAINNET_CHAIN_ID).eth.accounts.signTransaction(paramsObject, this.state.mainnetMetaAccount.privateKey).then(signed => {
                           console.log("========= >>> SIGNED",signed)
                             core.getWeb3(MAINNET_CHAIN_ID).eth.sendSignedTransaction(signed.rawTransaction).on('receipt', async (receipt)=>{
@@ -1759,7 +1771,6 @@ export default class Exchange extends React.Component {
                                   nonce: manualNonce,
                                   from: this.state.daiAddress,
                                   value: 0,
-                                  gas: 240000,
                                   gasPrice: Math.round(gwei * 1000000000)
                                 }
                                 console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
@@ -1769,6 +1780,8 @@ export default class Exchange extends React.Component {
 
                                 console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
+                                estimateTxGas(core.getWeb3(MAINNET_CHAIN_ID), paramsObject, 240000).then((gas) => {
+                                  paramsObject.gas = gas;
                                 core.getWeb3(MAINNET_CHAIN_ID).eth.accounts.signTransaction(paramsObject, this.state.mainnetMetaAccount.privateKey).then(signed => {
                                   console.log("========= >>> SIGNED",signed)
                                     core.getWeb3(MAINNET_CHAIN_ID).eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
@@ -1784,11 +1797,13 @@ export default class Exchange extends React.Component {
                                       this.props.changeAlert({type: 'danger',message: err.toString()});
                                     }).then(console.log)
                                 });
+                                });
                               }
                             }).on('error', (err)=>{
                               this.props.changeAlert({type: 'danger',message: err.toString()});
                               console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
                             }).then(console.log)
+                        });
                         });
 
                       }else{
@@ -1802,7 +1817,6 @@ export default class Exchange extends React.Component {
                         let paramsObject = {
                           from: this.state.daiAddress,
                           value: 0,
-                          gas: 240000,
                           gasPrice: Math.round(gwei * 1000000000)
                         }
                         console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
@@ -1812,6 +1826,8 @@ export default class Exchange extends React.Component {
 
                         console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
+                        estimateTxGas(core.getWeb3(MAINNET_CHAIN_ID), paramsObject, 240000).then((gas) => {
+                          paramsObject.gas = gas;
                         core.getWeb3(MAINNET_CHAIN_ID).eth.accounts.signTransaction(paramsObject, this.state.mainnetMetaAccount.privateKey).then(signed => {
                           console.log("========= >>> SIGNED",signed)
                             core.getWeb3(MAINNET_CHAIN_ID).eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
@@ -1827,6 +1843,7 @@ export default class Exchange extends React.Component {
                               console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
                               this.props.changeAlert({type: 'danger',message: err.toString()});
                             }).then(console.log)
+                        });
                         });
 
                       }

--- a/src/components/WithdrawFromPrivate.js
+++ b/src/components/WithdrawFromPrivate.js
@@ -7,6 +7,7 @@ import Badges from "../components/Badges";
 import Blockies from 'react-blockies';
 import axios from 'axios';
 import i18n from '../i18n';
+import estimateTxGas from '../services/estimateGas';
 
 let pollInterval
 let metaReceiptTracker = {}
@@ -109,7 +110,7 @@ export default class SendToAddress extends React.Component {
     return ( parseFloat(this.state.badgeCount)>0 || (parseFloat(this.state.amount) > 0 && parseFloat(this.state.amount) <= parseFloat(this.state.fromBalance)))
   }
 
-  withdraw = () => {
+  withdraw = async () => {
     let { fromAddress, amount, metaAccount } = this.state;
 
 
@@ -124,18 +125,20 @@ export default class SendToAddress extends React.Component {
         if(amount>0){
           if(this.props.ERC20TOKEN){
             tx={
+              from: metaAccount.address,
               to:this.props.contracts[this.props.ERC20TOKEN]._address,
               data: this.props.contracts[this.props.ERC20TOKEN].transfer(this.props.address,this.props.web3.utils.toWei(""+amount,'ether')).encodeABI(),
-              gas: 60000,
               gasPrice: Math.round(1100000000)//1.1gwei
             }
+            tx.gas = await estimateTxGas(this.props.web3, tx, 60000)
           }else{
             tx={
+              from: metaAccount.address,
               to:this.props.address,
               value: this.props.web3.utils.toWei(amount,'ether'),
-              gas: 30000,
               gasPrice: Math.round(1100000000)//1.1gwei
             }
+            tx.gas = await estimateTxGas(this.props.web3, tx, 30000)
           }
 
           this.props.web3.eth.accounts.signTransaction(tx, metaAccount.privateKey).then(signed => {
@@ -160,12 +163,13 @@ export default class SendToAddress extends React.Component {
             console.log("WITHDRAW Badge ",b)
 
             tx={
+              from: metaAccount.address,
               to:this.props.contracts['Badges']._address,
               //.Badges.transferFrom(this.props.address,this.state.toAddress,this.props.badge.id)
               data: this.props.contracts['Badges'].transferFrom(fromAddress,this.props.address,this.state.fromBadges[b].id).encodeABI(),
-              gas: 240000,
               gasPrice: Math.round(1100000000)//1.1gwei
             }
+            tx.gas = await estimateTxGas(this.props.web3, tx, 240000)
 
             this.props.web3.eth.accounts.signTransaction(tx, metaAccount.privateKey).then(signed => {
                 this.props.web3.eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{

--- a/src/services/estimateGas.js
+++ b/src/services/estimateGas.js
@@ -1,0 +1,12 @@
+const GAS_BUFFER_NUMERATOR = 12;
+const GAS_BUFFER_DENOMINATOR = 10;
+
+module.exports = async function estimateTxGas(web3, tx, fallbackGas) {
+  try {
+    const estimate = await web3.eth.estimateGas(tx);
+    return Math.ceil((estimate * GAS_BUFFER_NUMERATOR) / GAS_BUFFER_DENOMINATOR);
+  } catch (err) {
+    console.log('estimateGas failed, using fallback', err);
+    return fallbackGas;
+  }
+};


### PR DESCRIPTION
## Summary

Adds `estimateTxGas` helper with a 20% buffer and replaces hard-coded gas limits on metaAccount `signTransaction` paths in App, Exchange, and WithdrawFromPrivate.

Closes #219

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`
