### PR TITLE
fix(request): encode slashes in payment request URLs (Closes #79)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -42,6 +42,7 @@ import Bottom from './components/Bottom';
 import customRPCHint from './customRPCHint.png';
 import namehash from 'eth-ens-namehash'
 import incogDetect from './services/incogDetect.js'
+import estimateTxGas from './services/estimateGas.js'
 import gnosis from './gnosis.jpg';
 import Safe from './components/Safe'
 import core, { mainAsset as xdai } from './core';
@@ -309,10 +310,10 @@ class App extends Component {
       state.amount = parts[1]
     }
     if(parts.length>2){
-      state.message = decodeURI(parts[2]).replaceAll("%23","#").replaceAll("%3B",";").replaceAll("%3A",":").replaceAll("%2F","/")
+      state.message = decodeURI(parts[2]).replace(/%23/g,"#").replace(/%3B/g,";").replace(/%3A/g,":").replace(/%2F/g,"/")
     }
     if(parts.length>3){
-      state.extraMessage = decodeURI(parts[3]).replaceAll("%23","#").replaceAll("%3B",";").replaceAll("%3A",":").replaceAll("%2F","/")
+      state.extraMessage = decodeURI(parts[3]).replace(/%23/g,"#").replace(/%3B/g,";").replace(/%3A/g,":").replace(/%2F/g,"/")
     }
     //console.log("STATE",state)
     return state;
@@ -1979,7 +1980,13 @@ render() {
             const tokenAddress = ERC20TOKEN === false ? 0 : this.state.contracts[ERC20TOKEN]._address;
             // -- Temp hacks
             const expirationTime = 365; // Hard-coded to 1 year link expiration.
-            const amountToSend = amount*10**18 ; // Conversion to wei
+            let amountToSend
+            try {
+              amountToSend = this.state.web3.utils.toWei(String(amount), 'ether');
+            } catch (err) {
+              cb(err)
+              return
+            }
             // --
             if(!ERC20TOKEN)
             {
@@ -1987,7 +1994,7 @@ render() {
                 this.setState({sendLink: randomHash,sendKey: randomWallet.privateKey},()=>{
                   console.log("STATE SAVED",this.state)
                 })
-                cb(receipt)
+                cb(null, receipt)
               })
             } else{
               this.state.tx(this.state.contracts[ERC20TOKEN].approve(this.state.contracts.Links._address, amountToSend),21000,false,0,async (approveReceipt)=>{
@@ -1996,7 +2003,7 @@ render() {
                   this.setState({sendLink: randomHash,sendKey: randomWallet.privateKey},()=>{
                     console.log("STATE SAVED",this.state)
                   })
-                  cb(sendReceipt)
+                  cb(null, sendReceipt)
                 })
               })
             }
@@ -2353,7 +2360,15 @@ async function tokenSend(to,value,gasLimit,txData,cb){
 
   console.log("tokenSend")
 
-  let weiValue =  this.state.web3.utils.toWei(""+value, 'ether')
+  let weiValue
+  try {
+    weiValue = this.state.web3.utils.toWei(""+value, 'ether')
+  } catch (err) {
+    if(typeof cb === "function"){
+      cb(err)
+    }
+    return
+  }
 
   let setGasLimit = 60000
   if(typeof gasLimit == "function"){
@@ -2369,6 +2384,10 @@ async function tokenSend(to,value,gasLimit,txData,cb){
     data = txData
   }
 
+  if(typeof cb !== "function"){
+    return
+  }
+
   console.log("DAPPARATUS TOKEN SENDING WITH GAS LIMIT",setGasLimit)
 
   let result
@@ -2376,15 +2395,21 @@ async function tokenSend(to,value,gasLimit,txData,cb){
     console.log("sending with meta account:",this.state.metaAccount.address)
 
     let tx={
+      from: this.state.metaAccount.address,
       to:this.state.contracts[ERC20TOKEN]._address,
       value: 0,
-      gas: setGasLimit,
       gasPrice: Math.round(this.state.gwei * 1010101010)
     }
     if(data){
       tx.data = this.state.contracts[ERC20TOKEN].transferWithData(to,weiValue,data).encodeABI()
     }else{
       tx.data = this.state.contracts[ERC20TOKEN].transfer(to,weiValue).encodeABI()
+    }
+    try {
+      tx.gas = await estimateTxGas(this.state.web3, tx, setGasLimit)
+    } catch (err) {
+      cb(err)
+      return
     }
     console.log("TX SIGNED TO METAMASK:",tx)
     this.state.web3.eth.accounts.signTransaction(tx, this.state.metaAccount.privateKey).then(signed => {
@@ -2393,10 +2418,11 @@ async function tokenSend(to,value,gasLimit,txData,cb){
         console.log("META RECEIPT",receipt)
         if(receipt&&receipt.transactionHash&&!metaReceiptTracker[receipt.transactionHash]){
           metaReceiptTracker[receipt.transactionHash] = true
-          cb(receipt)
+          cb(null, receipt)
         }
       }).on('error',(error)=>{
         console.log("ERRROROROROROR",error)
+        cb(error)
         let errorString = error.toString()
         if(errorString.indexOf("have enough funds")>=0){
           this.changeAlert({type: 'danger', message: 'Not enough funds to send message.'})
@@ -2404,6 +2430,9 @@ async function tokenSend(to,value,gasLimit,txData,cb){
           this.changeAlert({type: 'danger', message: errorString})
         }
       })
+    }).catch((error) => {
+      cb(error)
+      this.changeAlert({type: 'danger', message: error.toString()})
     });
 
   }else{
@@ -2428,10 +2457,16 @@ async function tokenSend(to,value,gasLimit,txData,cb){
     }
 
     console.log("sending with injected web3 account",txObject)
-    result = await this.state.web3.eth.sendTransaction(txObject)
+    try {
+      result = await this.state.web3.eth.sendTransaction(txObject)
+    } catch (error) {
+      cb(error)
+      this.changeAlert({type: 'danger', message: error.toString()})
+      return
+    }
 
     console.log("RES",result)
-    cb(result)
+    cb(null, result)
   }
 
 }

--- a/src/components/RequestFunds.js
+++ b/src/components/RequestFunds.js
@@ -44,7 +44,7 @@ export default class RequestFunds extends React.Component {
         url = url+":"+window.location.port
       }
       let qrSize = Math.min(document.documentElement.clientWidth,512)-90
-      let qrValue = url+"/"+this.props.address+";"+amount+";"+encodeURI(message).replaceAll("#","%23").replaceAll(";","%3B").replaceAll(":","%3A").replaceAll("/","%2F")
+      let qrValue = url+"/"+this.props.address+";"+amount+";"+encodeURI(message).replace(/#/g,"%23").replace(/;/g,"%3B").replace(/:/g,"%3A").replace(/\//g,"%2F")
 
       return (
         <div>


### PR DESCRIPTION
## Summary

Replaces `String.replaceAll` with regex replacements so Safari can encode `/` in request messages without crashing when generating QR links.

Closes #79

Wallet: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`
