### PR TITLE
fix(exchange): fallback when ethgasstation is unavailable (#256)

### DIFF
--- a/src/components/Exchange.js
+++ b/src/components/Exchange.js
@@ -20,6 +20,8 @@ import xdaiImg from '../images/xdai.jpg';
 import InputRange from 'react-input-range';
 import 'react-input-range/lib/css/index.css';
 import core from '../core';
+import estimateTxGas from '../services/estimateGas';
+import fetchMainnetGasPriceGwei from '../services/mainnetGasPrice';
 
 const MAINNET_CHAIN_ID = '1';
 const XDAI_CHAIN_ID = '100';
@@ -219,7 +221,6 @@ export default class Exchange extends React.Component {
                         let paramsObject = {
                           from: this.state.daiAddress,
                           value: amountInWei,
-                          gas: 120000,
                           gasPrice: Math.round(1.1 * 1000000000)
                         }
                         console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
@@ -229,7 +230,8 @@ export default class Exchange extends React.Component {
 
                         console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
-
+                        estimateTxGas(this.state.xdaiweb3, paramsObject, 120000).then((gas) => {
+                          paramsObject.gas = gas;
                         this.state.xdaiweb3.eth.accounts.signTransaction(paramsObject, this.state.xdaiMetaAccount.privateKey).then(signed => {
                           console.log("========= >>> SIGNED",signed)
                             this.state.xdaiweb3.eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
@@ -244,6 +246,7 @@ export default class Exchange extends React.Component {
                               this.props.changeAlert({type: 'danger',message: err.toString()});
                               this.setState({gettingGas:false})
                             }).then(console.log)
+                        });
                         });
 
                       }else{
@@ -507,77 +510,83 @@ export default class Exchange extends React.Component {
     return (this.state.daiSendToAddress && this.state.daiSendToAddress.length === 42 && parseFloat(this.state.daiSendAmount)>0 && parseFloat(this.state.daiSendAmount) <= parseFloat(this.props.daiBalance))
   }
   transferDai(destination,amount,message,cb) {
-    axios.get("https://ethgasstation.info/json/ethgasAPI.json", { crossdomain: true })
+    const web3 = core.getWeb3(MAINNET_CHAIN_ID);
+    fetchMainnetGasPriceGwei(web3, GASBOOSTPRICE)
     .catch((err)=>{
       console.log("Error getting gas price",err)
+      this.props.changeAlert({type: 'danger',message: "Could not fetch gas price. Please try again."});
+      this.setState({
+        daiToXdaiMode:false,
+        loaderBarColor:"#FFFFFF",
+        loaderBarStatusText:"",
+      })
     })
-    .then((response)=>{
-      if(response && response.data.average>0&&response.data.average<1000){
+    .then((gwei)=>{
+      if(gwei === undefined){
+        return
+      }
+
+      this.setState({
+        loaderBarColor:"#f5eb4a",
+        loaderBarStatusText:message,
+      })
+
+      if(this.state.mainnetMetaAccount){
+        //send funds using metaaccount on mainnet
+
+        let paramsObject = {
+          from: this.state.daiAddress,
+          value: 0,
+          gasPrice: Math.round(gwei * 1000000000)
+        }
+        console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
+
+        paramsObject.to = this.props.daiContract.options.address
+        paramsObject.data = this.props.daiContract.methods.transfer(
+          destination,
+          web3.utils.toWei(""+amount,"ether")
+        ).encodeABI()
+
+        console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
+
+        estimateTxGas(web3, paramsObject, 100000).then((gas) => {
+          paramsObject.gas = gas;
+        web3.eth.accounts.signTransaction(paramsObject, this.state.mainnetMetaAccount.privateKey).then(signed => {
+          console.log("========= >>> SIGNED",signed)
+            web3.eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
+              console.log("META RECEIPT",receipt)
+              if(receipt&&receipt.transactionHash&&!metaReceiptTracker[receipt.transactionHash]){
+                metaReceiptTracker[receipt.transactionHash] = true
+                cb(receipt)
+              }
+            }).on('error', (err)=>{
+              console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
+              this.props.changeAlert({type: 'danger',message: err.toString()});
+            }).then(console.log)
+        });
+        });
+
+      }else{
+        //send funds using metamask (or other injected web3 ... should be checked and on mainnet)
+        console.log("Depositing to ",toDaiBridgeAccount)
 
         this.setState({
           loaderBarColor:"#f5eb4a",
           loaderBarStatusText:message,
         })
 
-        response.data.average=response.data.average + (response.data.average*GASBOOSTPRICE)
-        let gwei = Math.round(response.data.average*100)/1000
-        if(this.state.mainnetMetaAccount){
-          //send funds using metaaccount on mainnet
-
-          let paramsObject = {
-            from: this.state.daiAddress,
-            value: 0,
-            gas: 100000,
-            gasPrice: Math.round(gwei * 1000000000)
+        let metaMaskDaiContract = new this.props.web3.eth.Contract(this.props.daiContract._jsonInterface, this.props.daiContract._address || this.props.daiContract.options.address)
+        console.log("CURRENT DAI CONTRACT YOU NEED TO GET ABI FROM:",this.props.daiContract)
+        this.props.tx(metaMaskDaiContract.methods.transfer(
+          destination,
+          web3.utils.toWei(""+amount,"ether")
+          ///TODO LET ME PASS IN A CERTAIN AMOUNT OF GAS INSTEAD OF LEANING BACK ON THE <GAS> COMPONENT!!!!!
+        ),120000,0,0,(receipt)=>{
+          if(receipt){
+            console.log("SESSION WITHDRAWN:",receipt)
+            cb(receipt)
           }
-          console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
-
-          paramsObject.to = this.props.daiContract.options.address
-          paramsObject.data = this.props.daiContract.methods.transfer(
-            destination,
-            core.getWeb3(MAINNET_CHAIN_ID).utils.toWei(""+amount,"ether")
-          ).encodeABI()
-
-          console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
-
-          core.getWeb3(MAINNET_CHAIN_ID).eth.accounts.signTransaction(paramsObject, this.state.mainnetMetaAccount.privateKey).then(signed => {
-            console.log("========= >>> SIGNED",signed)
-              core.getWeb3(MAINNET_CHAIN_ID).eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
-                console.log("META RECEIPT",receipt)
-                if(receipt&&receipt.transactionHash&&!metaReceiptTracker[receipt.transactionHash]){
-                  metaReceiptTracker[receipt.transactionHash] = true
-                  cb(receipt)
-                }
-              }).on('error', (err)=>{
-                console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
-                this.props.changeAlert({type: 'danger',message: err.toString()});
-              }).then(console.log)
-          });
-
-        }else{
-          //send funds using metamask (or other injected web3 ... should be checked and on mainnet)
-          console.log("Depositing to ",toDaiBridgeAccount)
-
-          this.setState({
-            loaderBarColor:"#f5eb4a",
-            loaderBarStatusText:message,
-          })
-
-          let metaMaskDaiContract = new this.props.web3.eth.Contract(this.props.daiContract._jsonInterface, this.props.daiContract._address || this.props.daiContract.options.address)
-          console.log("CURRENT DAI CONTRACT YOU NEED TO GET ABI FROM:",this.props.daiContract)
-          this.props.tx(metaMaskDaiContract.methods.transfer(
-            destination,
-            core.getWeb3(MAINNET_CHAIN_ID).utils.toWei(""+amount,"ether")
-            ///TODO LET ME PASS IN A CERTAIN AMOUNT OF GAS INSTEAD OF LEANING BACK ON THE <GAS> COMPONENT!!!!!
-          ),120000,0,0,(receipt)=>{
-            if(receipt){
-              console.log("SESSION WITHDRAWN:",receipt)
-              cb(receipt)
-            }
-          })
-        }
-      }else{
-        console.log("ERRORed RESPONSE FROM ethgasstation",response)
+        })
       }
     })
   }
@@ -703,7 +712,6 @@ export default class Exchange extends React.Component {
           let paramsObject = {
             from: this.state.daiAddress,
             value: amount,
-            gas: 240000,
             gasPrice: Math.round(gwei * 1000000000)
           }
           console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
@@ -717,6 +725,8 @@ export default class Exchange extends React.Component {
 
           console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
+          estimateTxGas(core.getWeb3(MAINNET_CHAIN_ID), paramsObject, 240000).then((gas) => {
+            paramsObject.gas = gas;
           core.getWeb3(MAINNET_CHAIN_ID).eth.accounts.signTransaction(paramsObject, this.state.mainnetMetaAccount.privateKey).then(signed => {
             console.log("========= >>> SIGNED",signed)
               core.getWeb3(MAINNET_CHAIN_ID).eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
@@ -729,6 +739,7 @@ export default class Exchange extends React.Component {
                 console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
                 this.props.changeAlert({type: 'danger',message: err.toString()});
               }).then(console.log)
+          });
           });
 
         }else{
@@ -892,7 +903,6 @@ export default class Exchange extends React.Component {
                     let paramsObject = {
                       from: this.state.daiAddress,
                       value: amountOfxDaiToDeposit,
-                      gas: 120000,
                       gasPrice: Math.round(1.1 * 1000000000)
                     }
                     console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
@@ -902,6 +912,8 @@ export default class Exchange extends React.Component {
 
                     console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
+                    estimateTxGas(core.getWeb3(XDAI_CHAIN_ID), paramsObject, 120000).then((gas) => {
+                      paramsObject.gas = gas;
                     core.getWeb3(XDAI_CHAIN_ID).eth.accounts.signTransaction(paramsObject, this.state.xdaiMetaAccount.privateKey).then(signed => {
                       console.log("========= >>> SIGNED",signed)
                         core.getWeb3(XDAI_CHAIN_ID).eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
@@ -916,6 +928,7 @@ export default class Exchange extends React.Component {
                           console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
                           this.props.changeAlert({type: 'danger',message: err.toString()});
                         }).then(console.log)
+                    });
                     });
 
                   }else{
@@ -1019,7 +1032,6 @@ export default class Exchange extends React.Component {
                       let paramsObject = {
                         from: this.state.daiAddress,
                         value: 0,
-                        gas: 120000,
                         gasPrice: Math.round(1.1 * 1000000000)
                       }
                       console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
@@ -1029,6 +1041,8 @@ export default class Exchange extends React.Component {
 
                       console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
+                      estimateTxGas(core.getWeb3(XDAI_CHAIN_ID), paramsObject, 120000).then((gas) => {
+                        paramsObject.gas = gas;
                       core.getWeb3(XDAI_CHAIN_ID).eth.accounts.signTransaction(paramsObject, this.state.xdaiMetaAccount.privateKey).then(signed => {
                         console.log("========= >>> SIGNED",signed)
                           core.getWeb3(XDAI_CHAIN_ID).eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
@@ -1043,6 +1057,7 @@ export default class Exchange extends React.Component {
                             console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
                             this.props.changeAlert({type: 'danger',message: err.toString()});
                           }).then(console.log)
+                      });
                       });
 
                     }else{
@@ -1319,12 +1334,13 @@ export default class Exchange extends React.Component {
                     from: this.state.daiAddress,
                     to: toDaiBridgeAccount,
                     value: core.getWeb3(XDAI_CHAIN_ID).utils.toWei(""+this.state.amount,'ether'),
-                    gas: 120000,
                     gasPrice: Math.round(1.1 * 1000000000)
                   }
                   console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
                   console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
+                  estimateTxGas(core.getWeb3(XDAI_CHAIN_ID), paramsObject, 120000).then((gas) => {
+                    paramsObject.gas = gas;
                   core.getWeb3(XDAI_CHAIN_ID).eth.accounts.signTransaction(paramsObject, this.state.xdaiMetaAccount.privateKey).then(signed => {
                     console.log("========= >>> SIGNED",signed)
                       core.getWeb3(XDAI_CHAIN_ID).eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
@@ -1344,6 +1360,7 @@ export default class Exchange extends React.Component {
                         console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
                         this.props.changeAlert({type: 'danger',message: err.toString()});
                       }).then(console.log)
+                  });
                   });
 
                 }else{
@@ -1529,7 +1546,6 @@ export default class Exchange extends React.Component {
 
                 let output = await uniswapContract.methods.getTokenToEthOutputPrice(amountOfEth).call()
                 output = parseFloat(output)
-                output = output - (output*0.0333)
                 console.log("Expected amount of DAI: ",webToUse.utils.fromWei(""+Math.round(output),'ether'))
 
                 let currentBlockNumber = await webToUse.eth.getBlockNumber()
@@ -1671,7 +1687,7 @@ export default class Exchange extends React.Component {
 
                 let output = await uniswapContract.methods.getEthToTokenOutputPrice(amountOfDai).call()
                 output = parseFloat(output)
-                output = Math.round(output - (output*0.0333))
+                output = Math.round(output)
                 console.log("Expected amount of ETH: ",output,webToUse.utils.fromWei(""+ output,'ether'))
 
                 let currentBlockNumber = await webToUse.eth.getBlockNumber()
@@ -1730,7 +1746,6 @@ export default class Exchange extends React.Component {
                         let paramsObject = {
                           from: this.state.daiAddress,
                           value: 0,
-                          gas: 100000,
                           gasPrice: Math.round(gwei * 1000000000)
                         }
                         console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
@@ -1740,6 +1755,8 @@ export default class Exchange extends React.Component {
 
                         console.log("APPROVE TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
+                        estimateTxGas(core.getWeb3(MAINNET_CHAIN_ID), paramsObject, 100000).then((gas) => {
+                          paramsObject.gas = gas;
                         core.getWeb3(MAINNET_CHAIN_ID).eth.accounts.signTransaction(paramsObject, this.state.mainnetMetaAccount.privateKey).then(signed => {
                           console.log("========= >>> SIGNED",signed)
                             core.getWeb3(MAINNET_CHAIN_ID).eth.sendSignedTransaction(signed.rawTransaction).on('receipt', async (receipt)=>{
@@ -1759,7 +1776,6 @@ export default class Exchange extends React.Component {
                                   nonce: manualNonce,
                                   from: this.state.daiAddress,
                                   value: 0,
-                                  gas: 240000,
                                   gasPrice: Math.round(gwei * 1000000000)
                                 }
                                 console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
@@ -1769,6 +1785,8 @@ export default class Exchange extends React.Component {
 
                                 console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
+                                estimateTxGas(core.getWeb3(MAINNET_CHAIN_ID), paramsObject, 240000).then((gas) => {
+                                  paramsObject.gas = gas;
                                 core.getWeb3(MAINNET_CHAIN_ID).eth.accounts.signTransaction(paramsObject, this.state.mainnetMetaAccount.privateKey).then(signed => {
                                   console.log("========= >>> SIGNED",signed)
                                     core.getWeb3(MAINNET_CHAIN_ID).eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
@@ -1784,11 +1802,13 @@ export default class Exchange extends React.Component {
                                       this.props.changeAlert({type: 'danger',message: err.toString()});
                                     }).then(console.log)
                                 });
+                                });
                               }
                             }).on('error', (err)=>{
                               this.props.changeAlert({type: 'danger',message: err.toString()});
                               console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
                             }).then(console.log)
+                        });
                         });
 
                       }else{
@@ -1802,7 +1822,6 @@ export default class Exchange extends React.Component {
                         let paramsObject = {
                           from: this.state.daiAddress,
                           value: 0,
-                          gas: 240000,
                           gasPrice: Math.round(gwei * 1000000000)
                         }
                         console.log("====================== >>>>>>>>> paramsObject!!!!!!!",paramsObject)
@@ -1812,6 +1831,8 @@ export default class Exchange extends React.Component {
 
                         console.log("TTTTTTTTTTTTTTTTTTTTTX",paramsObject)
 
+                        estimateTxGas(core.getWeb3(MAINNET_CHAIN_ID), paramsObject, 240000).then((gas) => {
+                          paramsObject.gas = gas;
                         core.getWeb3(MAINNET_CHAIN_ID).eth.accounts.signTransaction(paramsObject, this.state.mainnetMetaAccount.privateKey).then(signed => {
                           console.log("========= >>> SIGNED",signed)
                             core.getWeb3(MAINNET_CHAIN_ID).eth.sendSignedTransaction(signed.rawTransaction).on('receipt', (receipt)=>{
@@ -1827,6 +1848,7 @@ export default class Exchange extends React.Component {
                               console.log("EEEERRRRRRRROOOOORRRRR ======== >>>>>",err)
                               this.props.changeAlert({type: 'danger',message: err.toString()});
                             }).then(console.log)
+                        });
                         });
 
                       }

--- a/src/services/mainnetGasPrice.js
+++ b/src/services/mainnetGasPrice.js
@@ -1,0 +1,26 @@
+const axios = require('axios');
+
+const ETH_GAS_STATION_URL = 'https://ethgasstation.info/json/ethgasAPI.json';
+const REQUEST_TIMEOUT_MS = 8000;
+
+async function fetchMainnetGasPriceGwei(web3, gasBoostPrice = 0.25) {
+  try {
+    const response = await axios.get(ETH_GAS_STATION_URL, {
+      crossdomain: true,
+      timeout: REQUEST_TIMEOUT_MS,
+    });
+    if (response && response.data && response.data.average > 0 && response.data.average < 1000) {
+      const boosted = response.data.average + response.data.average * gasBoostPrice;
+      return Math.round(boosted * 100) / 1000;
+    }
+    console.log('ethgasstation returned unusable gas data', response && response.data);
+  } catch (err) {
+    console.log('ethgasstation unavailable, falling back to node gas price', err);
+  }
+
+  const wei = await web3.eth.getGasPrice();
+  const boostedWei = Math.ceil(parseInt(wei, 10) * (1 + gasBoostPrice));
+  return Math.max(Math.round(boostedWei / 1e8) / 10, 1);
+}
+
+module.exports = fetchMainnetGasPriceGwei;


### PR DESCRIPTION
## Summary

Fixes DAI → xDai conversions getting stuck on **Calculating gas** when
`ethgasstation.info` is down or returns unusable data (#256).

## Changes

- `src/services/mainnetGasPrice.js` — try ethgasstation with timeout, then fall
  back to `web3.eth.getGasPrice()` with the existing boost multiplier
- `src/components/Exchange.js` — `transferDai()` uses the helper and clears the
  loader with an error alert when gas lookup fails entirely

## Why

`transferDai()` previously depended on ethgasstation succeeding silently; when
the API failed, the UI stayed on the calculating-gas state forever and never
broadcast the bridge transfer.

## Wallet

`Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

Fixes #256
