### PR TITLE
fix: Wyre widget crash on Buy button (#179)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "autolinker": "^2.2.1",
     "axios": "^0.18.0",
     "base64url": "^3.0.1",
-    "bootstrap": "^4.1.3",
     "cors": "^2.8.4",
     "crypto": "^1.0.1",
     "dapparatus": "^1.0.72",

--- a/src/components/Admin.js
+++ b/src/components/Admin.js
@@ -1,240 +1,199 @@
 import React from 'react';
 import { Scaler } from "dapparatus";
 import Blockies from 'react-blockies';
-import Ruler from "./Ruler";
-import {CopyToClipboard} from "react-copy-to-clipboard";
 import i18next from 'i18next';
-const QRCode = require('qrcode.react');
+import {
+  Box,
+  Button,
+  Card,
+  Field,
+  Flex,
+  Input
+} from 'rimble-ui';
 
-export default class Advanced extends React.Component {
-
+export default class Admin extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       changingAllowed: {},
-    }
+    };
   }
-  render(){
-    let {buttonStyle,contracts,tx,web3,vendors} = this.props
 
-    let vendorBlockie = ""
-    if(this.state.newVendor){
-      vendorBlockie = (
-        <Blockies seed={this.state.newVendor} scale={5}/>
-      )
+  render() {
+    let { buttonStyle, contracts, tx, web3, vendors } = this.props;
+
+    let vendorBlockie = "";
+    if (this.state.newVendor) {
+      vendorBlockie = <Blockies seed={this.state.newVendor} scale={5} />;
     }
 
-    let adminBlockie = ""
-    if(this.state.newAdmin){
-      adminBlockie = (
-        <Blockies seed={this.state.newAdmin} scale={5}/>
-      )
-    }
-
-    let vendorDisplay = []
-    for(let v in vendors){
+    let vendorDisplay = [];
+    for (let v in vendors) {
       let vendorButton = (
-        <button disabled={!vendors[v].isActive||!vendors[v].isAllowed} className="btn btn-large w-100"
-          onClick={()=>{
-            window.location = "/vendors;"+vendors[v].vendor
-          }}
-          style={this.props.buttonStyle.secondary}>
-          <Scaler config={{startZoomAt:600,origin:"10% 50%"}}>
+        <Button
+          disabled={!vendors[v].isActive || !vendors[v].isAllowed}
+          width={1}
+          onClick={() => { window.location = "/vendors;" + vendors[v].vendor; }}
+        >
+          <Scaler config={{ startZoomAt: 600, origin: "10% 50%" }}>
             {vendors[v].name}
           </Scaler>
-        </button>
-      )
+        </Button>
+      );
 
-
-      let vendorAllowedDisplay = ""
-      if(this.state.changingAllowed[v]){
-        vendorAllowedDisplay = (
-          <i className="fas fa-cog fa-spin"></i>
-        )
-      }else if(vendors[v].isAllowed){
-        vendorAllowedDisplay = (
-          <i className="fas fa-lock-open"></i>
-        )
-      }else{
-        vendorAllowedDisplay = (
-          <i className="fas fa-lock"></i>
-        )
+      let vendorAllowedDisplay;
+      if (this.state.changingAllowed[v]) {
+        vendorAllowedDisplay = <i className="fas fa-cog fa-spin" />;
+      } else if (vendors[v].isAllowed) {
+        vendorAllowedDisplay = <i className="fas fa-lock-open" />;
+      } else {
+        vendorAllowedDisplay = <i className="fas fa-lock" />;
       }
 
       let vendorIsAllowed = (
-        <button className="btn btn-large w-100"
-          onClick={()=>{
-            let {changingAllowed} = this.state
-            changingAllowed[v] = true
-            this.setState({changingAllowed})
-            //updateVendor(address wallet, bytes32 name, bool newAllowed)
-            tx(contracts[this.props.ERC20VENDOR].updateVendor(vendors[v].vendor,web3.utils.utf8ToHex(vendors[v].name),vendors[v].isActive,!vendors[v].isAllowed),120000,0,0,(result)=>{
-              console.log("ACTIVE:",result)
-              setTimeout(()=>{
-                let {changingAllowed} = this.state
-                changingAllowed[v] = false
-                this.setState({changingAllowed})
-              },1500)
-            })
+        <Button
+          width={1}
+          onClick={() => {
+            let changingAllowed = { ...this.state.changingAllowed };
+            changingAllowed[v] = true;
+            this.setState({ changingAllowed });
+            tx(
+              contracts[this.props.ERC20VENDOR].updateVendor(
+                vendors[v].vendor,
+                web3.utils.utf8ToHex(vendors[v].name),
+                vendors[v].isActive,
+                !vendors[v].isAllowed
+              ),
+              120000, 0, 0,
+              () => {
+                setTimeout(() => {
+                  changingAllowed = { ...this.state.changingAllowed };
+                  changingAllowed[v] = false;
+                  this.setState({ changingAllowed });
+                }, 1500);
+              }
+            );
           }}
-          style={this.props.buttonStyle.secondary}>
-          <Scaler config={{startZoomAt:500,origin:"50% 50%"}}>
+        >
+          <Scaler config={{ startZoomAt: 500, origin: "50% 50%" }}>
             {vendorAllowedDisplay}
           </Scaler>
-        </button>
-      )
+        </Button>
+      );
 
-
-      let vendorActiveDisplay = ""
-      if(this.state.changingAllowed[v]){
-        vendorActiveDisplay = (
-          <i className="fas fa-cog fa-spin"></i>
-        )
-      }else if(vendors[v].isActive){
-        vendorActiveDisplay = (
-          <i className="fas fa-thumbs-up"></i>
-        )
-      }else{
-        vendorActiveDisplay = (
-          <i className="fas fa-thumbs-down"></i>
-        )
+      let vendorActiveDisplay;
+      if (this.state.changingAllowed[v]) {
+        vendorActiveDisplay = <i className="fas fa-cog fa-spin" />;
+      } else if (vendors[v].isActive) {
+        vendorActiveDisplay = <i className="fas fa-thumbs-up" />;
+      } else {
+        vendorActiveDisplay = <i className="fas fa-thumbs-down" />;
       }
 
       let vendorIsActive = (
-        <button className="btn btn-large w-100"
-          onClick={()=>{
-            let {changingAllowed} = this.state
-            changingAllowed[v] = true
-            this.setState({changingAllowed})
-            //updateVendor(address wallet, bytes32 name, bool newAllowed)
-            tx(contracts[this.props.ERC20VENDOR].updateVendor(vendors[v].vendor,web3.utils.utf8ToHex(vendors[v].name),!vendors[v].isActive,vendors[v].isAllowed),120000,0,0,(result)=>{
-              console.log("ACTIVE:",result)
-              setTimeout(()=>{
-                let {changingAllowed} = this.state
-                changingAllowed[v] = false
-                this.setState({changingAllowed})
-              },1500)
-            })
+        <Button
+          width={1}
+          onClick={() => {
+            let changingAllowed = { ...this.state.changingAllowed };
+            changingAllowed[v] = true;
+            this.setState({ changingAllowed });
+            tx(
+              contracts[this.props.ERC20VENDOR].updateVendor(
+                vendors[v].vendor,
+                web3.utils.utf8ToHex(vendors[v].name),
+                !vendors[v].isActive,
+                vendors[v].isAllowed
+              ),
+              120000, 0, 0,
+              () => {
+                setTimeout(() => {
+                  changingAllowed = { ...this.state.changingAllowed };
+                  changingAllowed[v] = false;
+                  this.setState({ changingAllowed });
+                }, 1500);
+              }
+            );
           }}
-          style={this.props.buttonStyle.secondary}>
-          <Scaler config={{startZoomAt:500,origin:"50% 50%"}}>
+        >
+          <Scaler config={{ startZoomAt: 500, origin: "50% 50%" }}>
             {vendorActiveDisplay}
           </Scaler>
-        </button>
-      )
-
-
+        </Button>
+      );
 
       vendorDisplay.push(
-        <div key={v} className="content bridge row">
-          <div className="col-2 p-1" style={{textAlign:'center'}}>
-            <Blockies seed={vendors[v].vendor.toLowerCase()} scale={5}/>
-          </div>
-          <div className="col-6 p-1" style={{textAlign:'center'}}>
+        <Flex key={v} alignItems="center" mx={-1} mb={2}>
+          <Box width={2 / 12} px={1} textAlign="center">
+            <Blockies seed={vendors[v].vendor.toLowerCase()} scale={5} />
+          </Box>
+          <Box width={6 / 12} px={1} textAlign="center">
             {vendorButton}
-          </div>
-          <div className="col-2 p-1" style={{textAlign:'center'}}>
+          </Box>
+          <Box width={2 / 12} px={1} textAlign="center">
             {vendorIsActive}
-          </div>
-          <div className="col-2 p-1" style={{textAlign:'center'}}>
+          </Box>
+          <Box width={2 / 12} px={1} textAlign="center">
             {vendorIsAllowed}
-          </div>
-        </div>
-      )
+          </Box>
+        </Flex>
+      );
     }
 
-    /*
-    let addAdminText = (
-      <span>
-        <i className="fas fa-user-astronaut"></i> {i18next.t('admin.add_admin')}
-      </span>
-    )
-    if(this.state.addingAdmin){
-      addAdminText = (
-        <span>
-          <i className="fas fa-cog fa-spin"></i> {i18next.t('admin.adding')}
-        </span>
-      )
-    }*/
-
-    let addVendorText = (
-      <span>
-        <i className="fas fa-user"></i> {i18next.t('admin.add_vendor')}
-      </span>
-    )
-    if(this.state.addingVendor){
-      addVendorText = (
-        <span>
-          <i className="fas fa-cog fa-spin"></i> {i18next.t('admin.adding')}
-        </span>
-      )
-    }
-
+    let addVendorText = this.state.addingVendor
+      ? <><i className="fas fa-cog fa-spin" /> {i18next.t('admin.adding')}</>
+      : <><i className="fas fa-user" /> {i18next.t('admin.add_vendor')}</>;
 
     return (
-      <div className="main-card card w-100">
-
+      <Card width={1}>
         {vendorDisplay}
 
-        <div className="content bridge row">
-          <div className="col-1 p-1">
+        <Flex alignItems="flex-end" mx={-1} mt={3}>
+          <Box width={1 / 12} px={1}>
             {vendorBlockie}
-          </div>
-          <div className="col-3 p-1">
-            <input type="text" className="form-control" placeholder="0x..." value={this.state.newVendor}
-                   onChange={event => this.setState({newVendor:event.target.value})} />
-          </div>
-          <div className="col-4 p-1">
-            <input type="text" className="form-control" placeholder="Joe's Pizza" value={this.state.newVendorName}
-                   onChange={event => this.setState({newVendorName:event.target.value})} />
-          </div>
-          <div className="col-4 p-1">
-          <button className="btn btn-large w-100" style={this.props.buttonStyle.secondary} onClick={()=>{
-            this.setState({addingVendor:true})
-            tx(contracts[this.props.ERC20VENDOR].addVendor(this.state.newVendor,web3.utils.utf8ToHex(this.state.newVendorName)),480000,0,0,(result)=>{
-              console.log("VENDOR ADDED",result)
-              this.setState({newVendor:"",newVendorName:""})
-              setTimeout(()=>{
-                this.setState({addingVendor:false})
-              },1500)
-            })
-          }}>
-            <Scaler config={{startZoomAt:600,origin:"20% 50%"}}>
-              {addVendorText}
-            </Scaler>
-          </button>
-          </div>
-        </div>
-
-      </div>
-    )
+          </Box>
+          <Box width={3 / 12} px={1}>
+            <Field label="Address">
+              <Input
+                placeholder="0x..."
+                value={this.state.newVendor || ''}
+                onChange={event => this.setState({ newVendor: event.target.value })}
+              />
+            </Field>
+          </Box>
+          <Box width={4 / 12} px={1}>
+            <Field label="Name">
+              <Input
+                placeholder="Joe's Pizza"
+                value={this.state.newVendorName || ''}
+                onChange={event => this.setState({ newVendorName: event.target.value })}
+              />
+            </Field>
+          </Box>
+          <Box width={4 / 12} px={1}>
+            <Button
+              width={1}
+              onClick={() => {
+                this.setState({ addingVendor: true });
+                tx(
+                  contracts[this.props.ERC20VENDOR].addVendor(
+                    this.state.newVendor,
+                    web3.utils.utf8ToHex(this.state.newVendorName)
+                  ),
+                  480000, 0, 0,
+                  () => {
+                    this.setState({ newVendor: "", newVendorName: "" });
+                    setTimeout(() => { this.setState({ addingVendor: false }); }, 1500);
+                  }
+                );
+              }}
+            >
+              <Scaler config={{ startZoomAt: 600, origin: "20% 50%" }}>
+                {addVendorText}
+              </Scaler>
+            </Button>
+          </Box>
+        </Flex>
+      </Card>
+    );
   }
 }
-/*
-<div className="content bridge row">
-  <div className="col-1 p-1">
-    {adminBlockie}
-  </div>
-  <div className="col-7 p-1">
-    <input type="text" className="form-control" placeholder="0x..." value={this.state.newAdmin}
-           onChange={event => this.setState({newAdmin:event.target.value})} />
-  </div>
-  <div className="col-4 p-1">
-  <button className="btn btn-large w-100" style={this.props.buttonStyle.secondary} onClick={()=>{
-    this.setState({addingAdmin:true})
-    console.log("CONTRACTSSSSSSS",this.props.ERC20VENDOR,this.props.contracts)
-    tx(this.props.contracts[this.props.ERC20VENDOR].addAdmin(this.state.newAdmin),240000,false,0,(result)=>{
-      console.log("ADMIN ADDED",result)
-      this.setState({newAdmin:""})
-      setTimeout(()=>{
-        this.setState({addingAdmin:false})
-      },1500)
-    })
-  }}>
-    <Scaler config={{startZoomAt:600,origin:"20% 50%"}}>
-      {addAdminText}
-    </Scaler>
-  </button>
-  </div>
-</div>
- */

--- a/src/components/Advanced.js
+++ b/src/components/Advanced.js
@@ -7,6 +7,10 @@ import {
   Button,
   OutlineButton,
   Input,
+  Flex,
+  Box,
+  Text,
+  Card,
   QR as QRCode
 } from 'rimble-ui'
 
@@ -30,58 +34,56 @@ export default class Advanced extends React.Component {
     let qrSize = Math.min(document.documentElement.clientWidth,512)-90
     let qrValue = url+"/#"+privateKey
     let privateKeyQrDisplay = ""
-    if(this.state.privateKeyQr){
+    if (this.state.privateKeyQr) {
       privateKeyQrDisplay = (
-        <div className="main-card card w-100">
-          <div className="content qr row">
-            <QRCode value={qrValue} size={qrSize}/>
-          </div>
-        </div>
-      )
+        <Card width={1}>
+          <Flex flexDirection="column" alignItems="center" p={3}>
+            <QRCode value={qrValue} size={qrSize} renderAs="svg" />
+          </Flex>
+        </Card>
+      );
     }
 
-    let showingQr = ""
-    if(this.state.showingQr){
+    let showingQr = "";
+    if (this.state.showingQr) {
       showingQr = (
-        <div className="main-card card w-100">
-          <div className="content qr row">
-            <QRCode value={this.state.showingQr} size={qrSize}/>
-          </div>
-        </div>
-      )
+        <Card width={1} mt={3}>
+          <Flex flexDirection="column" alignItems="center" p={3}>
+            <QRCode value={this.state.showingQr} size={qrSize} renderAs="svg" />
+          </Flex>
+        </Card>
+      );
     }
 
+    let inputPrivateEyeButton = null;
+    let inputPrivateWidth = 4 / 12;
 
-    let inputPrivateEyeButton = ""
-    let inputPrivateSize = "col-4 p-1"
-
-    if(this.state.newPrivateKey){
+    if (this.state.newPrivateKey) {
       inputPrivateEyeButton = (
-        <div className="col-2 p-1">
-          <Button onClick={()=>{this.setState({privateKeyHidden:!this.state.privateKeyHidden})}}>
+        <Box width={2 / 12} px={2}>
+          <Button width={1} onClick={() => { this.setState({ privateKeyHidden: !this.state.privateKeyHidden }); }}>
             <i className="fas fa-eye"></i>
           </Button>
-        </div>
-      )
-    }else{
-      inputPrivateSize = "col-6 p-1"
+        </Box>
+      );
+    } else {
+      inputPrivateWidth = 6 / 12;
     }
 
     let inputPrivateKeyRow = (
-      <div className="content ops row">
-        <div className={inputPrivateSize}>
+      <Flex alignItems="center" mx={-2}>
+        <Box width={inputPrivateWidth} px={2}>
           <Input
-            type={this.state.privateKeyHidden?"password":"text"}
+            type={this.state.privateKeyHidden ? "password" : "text"}
             autocorrect="off"
             autocapitalize="none"
-            className="form-control"
             placeholder="private key"
-            value={this.state.newPrivateKey}
-            onChange={event => this.setState({newPrivateKey:event.target.value})}
+            value={this.state.newPrivateKey || ''}
+            onChange={event => this.setState({ newPrivateKey: event.target.value })}
           />
-        </div>
+        </Box>
         {inputPrivateEyeButton}
-        <div className="col-6 p-1">
+        <Box width={6 / 12} px={2}>
           <Button width={1} onClick={()=>{
                     console.log(this.state.newPrivateKey)
                     if(this.state && this.state.newPrivateKey && this.state.newPrivateKey.length>=64&&this.state.newPrivateKey.length<=66){
@@ -101,41 +103,39 @@ export default class Advanced extends React.Component {
               <i className="fas fa-plus-square"/> {i18n.t('create')}
             </Scaler>
           </Button>
-        </div>
-      </div>
-    )
+        </Box>
+      </Flex>
+    );
 
+    let inputSeedEyeButton = null;
+    let inputSeedWidth = 4 / 12;
 
-    let inputSeedEyeButton = ""
-    let inputSeedSize = "col-4 p-1"
-
-    if(this.state.newSeedPhrase){
+    if (this.state.newSeedPhrase) {
       inputSeedEyeButton = (
-        <div className="col-2 p-1">
-          <Button width={1} onClick={()=>{this.setState({seedPhraseHidden:!this.state.seedPhraseHidden})}}>
+        <Box width={2 / 12} px={2}>
+          <Button width={1} onClick={() => { this.setState({ seedPhraseHidden: !this.state.seedPhraseHidden }); }}>
             <i className="fas fa-eye"></i>
           </Button>
-        </div>
-      )
-    }else{
-      inputSeedSize = "col-6 p-1"
+        </Box>
+      );
+    } else {
+      inputSeedWidth = 6 / 12;
     }
 
     let inputSeedRow = (
-      <div className="content ops row" style={{paddingTop:10}}>
-        <div className={inputSeedSize}>
+      <Flex alignItems="center" mx={-2} pt={3}>
+        <Box width={inputSeedWidth} px={2}>
           <Input
-            type={this.state.seedPhraseHidden?"password":"text"}
+            type={this.state.seedPhraseHidden ? "password" : "text"}
             autocorrect="off"
             autocapitalize="none"
-            className="form-control"
             placeholder="seed phrase"
-            value={this.state.newSeedPhrase}
-            onChange={event => this.setState({newSeedPhrase:event.target.value})}
+            value={this.state.newSeedPhrase || ''}
+            onChange={event => this.setState({ newSeedPhrase: event.target.value })}
           />
-        </div>
+        </Box>
         {inputSeedEyeButton}
-        <div className="col-6 p-1">
+        <Box width={6 / 12} px={2}>
           <Button width={1} onClick={()=>{
                     if(!this.state.newSeedPhrase){
                       changeAlert({type: 'warning', message: 'Invalid seed phrase.'})
@@ -150,143 +150,114 @@ export default class Advanced extends React.Component {
               <i className="fas fa-plus-square"/> {i18n.t('create')}
             </Scaler>
           </Button>
-        </div>
-      </div>
-    )
+        </Box>
+      </Flex>
+    );
 
     return (
-      <div style={{marginTop:20}}>
+      <Box mt={4}>
+        <Box>
+          <Text textAlign="center" width={1} fontWeight="bold">Learn More</Text>
+          <Flex mx={-2} mb={3} mt={3}>
+            <Box width={1 / 2} px={2}>
+              <a href="https://github.com/austintgriffith/burner-wallet" style={{ color: "#FFFFFF" }} target="_blank" rel="noopener noreferrer">
+                <OutlineButton width={1}>
+                  <Scaler config={{ startZoomAt: 400, origin: "50% 50%" }}>
+                    <i className="fas fa-code" /> {i18n.t('code')}
+                  </Scaler>
+                </OutlineButton>
+              </a>
+            </Box>
+            <Box width={1 / 2} px={2}>
+              <a href="https://medium.com/gitcoin/ethereum-in-emerging-economies-b235f8dac2f2" style={{ color: "#FFFFFF" }} target="_blank" rel="noopener noreferrer">
+                <OutlineButton width={1}>
+                  <Scaler config={{ startZoomAt: 400, origin: "50% 50%" }}>
+                    <i className="fas fa-info" /> {i18n.t('about')}
+                  </Scaler>
+                </OutlineButton>
+              </a>
+            </Box>
+          </Flex>
+        </Box>
 
-      <div>
-        <div style={{width:"100%",textAlign:"center"}}><h5>Learn More</h5></div>
-        <div className="content ops row" style={{marginBottom:10}}>
-          <div className="col-6 p-1">
-            <a href="https://github.com/austintgriffith/burner-wallet" style={{color:"#FFFFFF"}} target="_blank">
-              <OutlineButton width={1}>
-                <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-                  <i className="fas fa-code"/> {i18n.t('code')}
-                </Scaler>
-              </OutlineButton>
-            </a>
-          </div>
-          <div className="col-6 p-1">
-            <a href="https://medium.com/gitcoin/ethereum-in-emerging-economies-b235f8dac2f2" style={{color:"#FFFFFF"}} target="_blank">
-              <OutlineButton width={1}>
-                <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-                  <i className="fas fa-info"/> {i18n.t('about')}
-                </Scaler>
-              </OutlineButton>
-            </a>
-          </div>
-        </div>
-      </div>
-
-      <hr style={{paddingTop:20}}/>
-
-
+        <hr style={{ paddingTop: 20 }} />
 
         {privateKey && !isVendor &&
-        <div>
-                    <div style={{width:"100%",textAlign:"center"}}><h5>Private Key</h5></div>
-          <div className="content ops row" style={{marginBottom:10}}>
-
-            <div className="col-6 p-1">
-            <Button width={1} onClick={()=>{
-              this.setState({privateKeyQr:!this.state.privateKeyQr})
-            }}>
-              <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-                <i className="fas fa-key"/> {i18n.t('show')}
-              </Scaler>
-            </Button>
-            </div>
-
-            <CopyToClipboard text={privateKey}>
-              <div className="col-6 p-1"
-                   onClick={() => changeAlert({type: 'success', message: 'Private Key copied to clipboard'})}>
-                <Button width={1}>
-                  <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-                    <i className="fas fa-key"/> {i18n.t('copy')}
+          <Box>
+            <Text textAlign="center" width={1} fontWeight="bold">Private Key</Text>
+            <Flex mx={-2} mb={3} mt={3}>
+              <Box width={1 / 2} px={2}>
+                <Button width={1} onClick={() => { this.setState({ privateKeyQr: !this.state.privateKeyQr }); }}>
+                  <Scaler config={{ startZoomAt: 400, origin: "50% 50%" }}>
+                    <i className="fas fa-key" /> {i18n.t('show')}
                   </Scaler>
                 </Button>
-              </div>
-            </CopyToClipboard>
-
-          </div>
-          <div className="content ops row">
+              </Box>
+              <CopyToClipboard text={privateKey}>
+                <Box width={1 / 2} px={2} onClick={() => changeAlert({ type: 'success', message: 'Private Key copied to clipboard' })}>
+                  <Button width={1}>
+                    <Scaler config={{ startZoomAt: 400, origin: "50% 50%" }}>
+                      <i className="fas fa-key" /> {i18n.t('copy')}
+                    </Scaler>
+                  </Button>
+                </Box>
+              </CopyToClipboard>
+            </Flex>
             {privateKeyQrDisplay}
-          </div>
-
-        </div>
+          </Box>
         }
 
         {privateKey &&
-        <div>
-          <div className="content ops row" >
-            <div className="col-12 p-1">
-              <Button width={1} onClick={()=>{
-                console.log("BALANCE",balance)
-                changeView('burn-wallet')
-              }}>
-                <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-                  <i className="fas fa-fire"/> {i18n.t('burn')}
+          <Box>
+            <Box px={2}>
+              <Button width={1} onClick={() => { changeView('burn-wallet'); }}>
+                <Scaler config={{ startZoomAt: 400, origin: "50% 50%" }}>
+                  <i className="fas fa-fire" /> {i18n.t('burn')}
                 </Scaler>
               </Button>
-            </div>
-          </div>
-          <hr style={{paddingTop:20}}/>
-        </div>}
+            </Box>
+            <hr style={{ paddingTop: 20 }} />
+          </Box>
+        }
 
-
-        <div style={{width:"100%",textAlign:"center"}}><h5>Create Account</h5></div>
-
+        <Text textAlign="center" width={1} fontWeight="bold">Create Account</Text>
         {inputPrivateKeyRow}
-
         {inputSeedRow}
 
-        <hr style={{paddingTop:20}}/>
-        <div style={{width:"100%",textAlign:"center"}}><h5>Extra Tools</h5></div>
+        <hr style={{ paddingTop: 20 }} />
+        <Text textAlign="center" width={1} fontWeight="bold">Extra Tools</Text>
 
-        <div className="content ops row">
-          <div className="col-6 p-1">
+        <Flex mx={-2} mt={3}>
+          <Box width={1 / 2} px={2}>
             <Input
               type="text"
               autocorrect="off"
               autocapitalize="none"
-              className="form-control"
               placeholder="any text to encode"
-              value={this.state.newQr}
-              onChange={event => this.setState({newQr:event.target.value})}
+              value={this.state.newQr || ''}
+              onChange={event => this.setState({ newQr: event.target.value })}
             />
-          </div>
-          <div className="col-6 p-1">
-            <Button width={1} onClick={()=>{
-              this.setState({showingQr:this.state.newQr})
-            }}>
-              <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-                <i className="fas fa-qrcode"/> {i18n.t('advanced.to_qr')}
+          </Box>
+          <Box width={1 / 2} px={2}>
+            <Button width={1} onClick={() => { this.setState({ showingQr: this.state.newQr }); }}>
+              <Scaler config={{ startZoomAt: 400, origin: "50% 50%" }}>
+                <i className="fas fa-qrcode" /> {i18n.t('advanced.to_qr')}
               </Scaler>
             </Button>
-          </div>
-        </div>
+          </Box>
+        </Flex>
         {showingQr}
 
         {isVendor &&
-        <div>
-          <div className="content ops row" style={{marginBottom:10}}>
-            <div className="col-12 p-1">
-              <Button width={1} onClick={()=>{
-                this.props.changeView("exchange")
-              }}>
-                <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-                  <i className="fas fa-key"/> {"Exchange"}
-                </Scaler>
-              </Button>
-            </div>
-          </div>
-        </div>
+          <Box px={2} mt={3}>
+            <Button width={1} onClick={() => { this.props.changeView("exchange"); }}>
+              <Scaler config={{ startZoomAt: 400, origin: "50% 50%" }}>
+                <i className="fas fa-key" /> Exchange
+              </Scaler>
+            </Button>
+          </Box>
         }
-
-      </div>
-    )
+      </Box>
+    );
   }
 }

--- a/src/components/BottomLinks.js
+++ b/src/components/BottomLinks.js
@@ -1,16 +1,20 @@
 import React from 'react';
 import { Scaler } from "dapparatus";
+import { Box, OutlineButton } from 'rimble-ui';
 import i18n from '../i18n';
-export default ({changeView}) => {
+
+export default ({ changeView }) => {
   return (
-    <div className="text-center bottom-text" style={{marginBottom:30}}>
-      <Scaler config={{startZoomAt:350,origin:"35% 50%",adjustedZoom:1}}>
-        <button className={"btn btn-large w-50"} style={{backgroundColor:"#666666",color:"#FFFFFF",padding:10,whiteSpace:"nowrap"}} onClick={()=>{changeView('advanced')}}>
-          <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-            <i className="fas fa-wrench"/> {i18n.t('advance')}
-          </Scaler>
-        </button>
+    <Box textAlign="center" className="bottom-text" mb={4}>
+      <Scaler config={{ startZoomAt: 350, origin: "35% 50%", adjustedZoom: 1 }}>
+        <OutlineButton
+          icon="Build"
+          width={0.5}
+          onClick={() => { changeView('advanced'); }}
+        >
+          {i18n.t('advance')}
+        </OutlineButton>
       </Scaler>
-    </div>
-  )
+    </Box>
+  );
 };

--- a/src/components/BurnWallet.js
+++ b/src/components/BurnWallet.js
@@ -1,39 +1,44 @@
 import React from 'react';
 import Ruler from "./Ruler";
-import Balance from "./Balance";
 import i18n from '../i18n';
+import {
+  Box,
+  Button,
+  Flex,
+  Text
+} from 'rimble-ui';
 
-
-
-export default ({mainStyle, address, balance, burnWallet, goBack, dollarDisplay}) => {
-
+export default ({ mainStyle, goBack, burnWallet }) => {
   return (
-
-    <div>
-      <div style={{textAlign:"center",width:"100%",fontWeight:'bold',fontSize:30}}>
+    <Box>
+      <Text textAlign="center" width={1} fontWeight="bold" fontSize={6}>
         {i18n.t('burn_wallet.burn_private_key_question')}
-      </div>
-      <div style={{textAlign:"center",marginTop:20,width:"100%",fontWeight:'bold',fontSize:20}}>
+      </Text>
+      <Text textAlign="center" mt={4} width={1} fontWeight="bold" fontSize={4}>
         {i18n.t('burn_wallet.disclaimer')}
-      </div>
-      <div>
-        <Ruler/>
-        <div className="content ops row">
-
-            <div className="col-6 p-1">
-              <button className="btn btn-large w-100" style={{backgroundColor:mainStyle.mainColor}} onClick={goBack} >
-                  <i className="fas fa-arrow-left"  /> {i18n.t('burn_wallet.cancel')}
-              </button>
-            </div>
-
-          <div className="col-6 p-1">
-            <button className="btn btn-large w-100" style={{backgroundColor:"#c53838"}} onClick={burnWallet}>
-                <i className="fas fa-fire"/> {i18n.t('burn_wallet.burn')}
-            </button>
-          </div>
-        </div>
-      </div>
-
-    </div>
-  )
-}
+      </Text>
+      <Ruler />
+      <Flex mx={-2}>
+        <Box width={1 / 2} px={2}>
+          <Button
+            icon="ArrowBack"
+            width={1}
+            onClick={goBack}
+          >
+            {i18n.t('burn_wallet.cancel')}
+          </Button>
+        </Box>
+        <Box width={1 / 2} px={2}>
+          <Button
+            icon="Whatshot"
+            width={1}
+            bg="#c53838"
+            onClick={burnWallet}
+          >
+            {i18n.t('burn_wallet.burn')}
+          </Button>
+        </Box>
+      </Flex>
+    </Box>
+  );
+};

--- a/src/components/CashOut.js
+++ b/src/components/CashOut.js
@@ -1,10 +1,14 @@
-import React, { Component }  from 'react';
-import { Scaler } from "dapparatus";
-let interval
+import React, { Component } from 'react';
+import {
+  Box,
+  Button,
+  Field,
+  Input
+} from 'rimble-ui';
 
-const OFFRAMPACCOUNT = "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+const OFFRAMPACCOUNT = "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF";
 
-class App extends Component {
+class CashOut extends Component {
   constructor(props) {
     super(props);
     this.state = {};
@@ -16,40 +20,33 @@ class App extends Component {
 
   render() {
     return (
-      <div style={{textAlign:'left'}}>
-        <div className="content row">
-
-        <div style={{marginTop:20,width:"100%",height:20}}>
-        </div>
-
-        <label htmlFor="amount_input">{"Initiate Wyre Transfer"}</label>
-
-        <div className="input-group">
-          <div className="input-group-prepend">
-            <div className="input-group-text">$</div>
-          </div>
-          <input type="number" className="form-control" placeholder="0.00" value={this.state.amount}
+      <Box textAlign="left" p={3}>
+        <Box mt={4} mb={4}>
+          <Field label="Initiate Wyre Transfer">
+            <Input
+              type="number"
+              placeholder="0.00"
+              value={this.state.amount || ''}
               ref={(input) => { this.amountInput = input; }}
-                 onChange={event => this.updateState('amount', event.target.value)} />
-        </div>
-        <div style={{marginTop:20,width:"100%",height:20}}>
-        </div>
-        <button className="btn btn-large w-100" style={this.props.buttonStyle.primary}
-                onClick={()=>{
-                  this.props.changeView('loader')
-                  setTimeout(()=>{
-                    //maybe they just scanned an address?
-                    window.location = "/"+OFFRAMPACCOUNT+";"+this.state.amount+";VENDOR%20CASH%20OUT"
-                  },100)
-                }}>
-          <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-            <i className="fas fa-play"/> {'Start'}
-          </Scaler>
-        </button>
-
-        </div>
-      </div>
-    )
+              onChange={event => this.updateState('amount', event.target.value)}
+            />
+          </Field>
+        </Box>
+        <Button
+          icon="PlayArrow"
+          width={1}
+          onClick={() => {
+            this.props.changeView('loader');
+            setTimeout(() => {
+              window.location = "/" + OFFRAMPACCOUNT + ";" + this.state.amount + ";VENDOR%20CASH%20OUT";
+            }, 100);
+          }}
+        >
+          Start
+        </Button>
+      </Box>
+    );
   }
 }
-export default App;
+
+export default CashOut;

--- a/src/components/Exchange.js
+++ b/src/components/Exchange.js
@@ -1986,11 +1986,18 @@ export default class Exchange extends React.Component {
         }
         onClick={()=>{
           this.setState({ wyreWidgetOpen: true });
-          Wyre.displayWidget(
+          const opened = Wyre.displayWidget(
               this.props.address,
               this.state.wyreFundAmount,
               () => { this.setState({ wyreWidgetOpen: false }); }
           );
+          if (!opened) {
+            this.setState({ wyreWidgetOpen: false });
+            this.props.changeAlert({
+              type: 'warning',
+              message: 'Wyre payment widget failed to load. Please refresh and try again.'
+            });
+          }
         }}
       ><Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
         <div style={{flex: '0 0 30px', textAlign: 'center'}}>

--- a/src/components/Exchange.js
+++ b/src/components/Exchange.js
@@ -18,7 +18,8 @@ import {
   OutlineButton,
   Icon,
   Input,
-  Field
+  Field,
+  Card
 } from 'rimble-ui'
 
 import Wyre from '../services/wyre';
@@ -180,8 +181,7 @@ export default class Exchange extends React.Component {
       let extraGasUpDisplay = (
         <div style={{padding:10,width:"100%",textAlign:'center',backgroundColor:"#ffdddd"}}>
           <div style={{padding:10}}>You have DAI but no ETH for gas:</div>
-          <button style={this.props.buttonStyle.secondary}
-            className="btn btn-large"
+          <Button style={this.props.buttonStyle.secondary}
             onClick={()=>{
               if(this.state.gettingGas){
                 this.props.changeAlert({type: 'warning',message: "Already trying to fuel up via xDai->ETH"});
@@ -276,7 +276,7 @@ export default class Exchange extends React.Component {
             }}
           >
            {getGasText}
-          </button>
+          </Button>
         </div>
 
       )
@@ -827,15 +827,12 @@ export default class Exchange extends React.Component {
     if(this.props.ERC20TOKEN){
       if(xdaiToDendaiMode=="sending" || xdaiToDendaiMode=="withdrawing" || xdaiToDendaiMode=="depositing"){
         xdaiToDendaiDisplay = (
-          <div className="content ops row" style={{position:"relative"}}>
-            <button style={{width:Math.min(100,this.state.loaderBarPercent)+"%",backgroundColor:this.state.loaderBarColor,color:"#000000"}}
-              className="btn btn-large"
-            >
-            </button>
-            <div style={{position:'absolute',left:"50%",width:"100%",marginLeft:"-50%",fontSize:adjustedFontSize,top:adjustedTop,opacity:0.95,textAlign:"center"}}>
+          <Box position="relative" width={1}>
+            <Box width={Math.min(100, this.state.loaderBarPercent) + '%'} height="32px" bg={this.state.loaderBarColor} />
+            <Box position="absolute" left="50%" width="100%" style={{ marginLeft: '-50%', fontSize: adjustedFontSize, top: adjustedTop, opacity: 0.95, textAlign: 'center' }}>
               {this.state.loaderBarStatusText}
-            </div>
-          </div>
+            </Box>
+          </Box>
         )
 
       }else if(xdaiToDendaiMode=="deposit"){
@@ -843,40 +840,35 @@ export default class Exchange extends React.Component {
         //console.log("CHECKING META ACCOUNT ",this.state.xdaiMetaAccount,this.props.network)
         if(!this.state.xdaiMetaAccount && (this.props.network!="xDai"&&this.props.network!="Unknown")){
           xdaiToDendaiDisplay = (
-            <div className="content ops row" style={{textAlign:'center'}}>
-              <div className="col-12 p-1">
+            <Flex alignItems="center" mx={-1} style={{textAlign:'center'}}>
+              <Box width={1} px={1}>
                 Error: MetaMask network must be: <span style={{fontWeight:"bold",marginLeft:5}}>dai.poa.network</span>
                 <a href="#" onClick={()=>{this.setState({xdaiToDendaiMode:false})}} style={{marginLeft:40,color:"#666666"}}>
                   <i className="fas fa-times"/> dismiss
                 </a>
-              </div>
-            </div>
+              </Box>
+            </Flex>
           )
         }else{
           xdaiToDendaiDisplay = (
-            <div className="content ops row">
+            <Flex alignItems="center" mx={-1}>
 
-              <div className="col-1 p-1"  style={colStyle}>
+              <Box width={1/12} px={1}  style={colStyle}>
                 <i className="fas fa-arrow-up"  />
-              </div>
-              <div className="col-5 p-1" style={colStyle}>
+              </Box>
+              <Box width={5/12} px={1} style={colStyle}>
                 <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-                <div className="input-group">
-                  <div className="input-group-prepend">
-                    <div className="input-group-text">$</div>
-                  </div>
-                  <input type="number" step="0.1" className="form-control" placeholder="0.00" value={this.state.amount}
-                         onChange={event => this.updateState('amount', event.target.value)} />
-                </div>
+                <Input type="number" step="0.1" placeholder="0.00" width={1} value={this.state.amount || ''}
+                       onChange={event => this.updateState('amount', event.target.value)} />
                 </Scaler>
-              </div>
-              <div className="col-3 p-1"  style={colStyle}>
+              </Box>
+              <Box width={3/12} px={1}  style={colStyle}>
                 <Scaler config={{startZoomAt:650,origin:"0% 85%"}}>
                 {xdaiCancelButton}
                 </Scaler>
-              </div>
-              <div className="col-3 p-1">
-                <button className="btn btn-large w-100"  disabled={buttonsDisabled} style={this.props.buttonStyle.primary} onClick={async ()=>{
+              </Box>
+              <Box width={3/12} px={1}>
+                <Button width={1} disabled={buttonsDisabled} onClick={async ()=>{
 
                   let amountOfxDaiToDeposit = this.state.xdaiweb3.utils.toWei(""+this.state.amount,'ether')
                   console.log("Using DenDai contract to deposit "+amountOfxDaiToDeposit+" xDai")
@@ -942,24 +934,24 @@ export default class Exchange extends React.Component {
                   <Scaler config={{startZoomAt:600,origin:"10% 50%"}}>
                     <i className="fas fa-arrow-up" /> Send
                   </Scaler>
-                </button>
+                </Button>
 
-              </div>
-            </div>
+              </Box>
+            </Flex>
           )
         }
       }else if(xdaiToDendaiMode=="withdraw"){
         console.log("CHECKING META ACCOUNT ",this.state.xdaiMetaAccount,this.props.network)
         if(!this.state.xdaiMetaAccount && (this.props.network!="xDai"&&this.props.network!="Unknown")){
           xdaiToDendaiDisplay = (
-            <div className="content ops row" style={{textAlign:'center'}}>
-              <div className="col-12 p-1">
+            <Flex alignItems="center" mx={-1} style={{textAlign:'center'}}>
+              <Box width={1} px={1}>
                 Error: MetaMask network must be: <span style={{fontWeight:"bold",marginLeft:5}}>dai.poa.network</span>
                 <a href="#" onClick={()=>{this.setState({xdaiToDendaiMode:false})}} style={{marginLeft:40,color:"#666666"}}>
                   <i className="fas fa-times"/> dismiss
                 </a>
-              </div>
-            </div>
+              </Box>
+            </Flex>
           )
         }else{
 
@@ -967,43 +959,38 @@ export default class Exchange extends React.Component {
 
           if(!this.props.isAdmin && (!this.props.isVendor || !this.props.isVendor.isAllowed)){
             extraWithdrawInfo = (
-              <div className="content ops row" style={{paddingTop:10}}>
-                <div style={{width:"100%",textAlign:'center'}}>
+              <Box pt={3} width={1}>
+                <Box width="100%" textAlign="center">
                   Maximum withdrawal amount: {this.props.dollarDisplay(this.state.maxWithdrawlAmount)}
-                </div>
-                <div style={{width:"100%",textAlign:'center',opacity:0.5}}>
+                </Box>
+                <Box width="100%" textAlign="center" style={{ opacity: 0.5 }}>
                   ({this.state.withdrawalExplanation})
-                </div>
-              </div>
+                </Box>
+              </Box>
             )
           }
 
 
           xdaiToDendaiDisplay = (
-            <div>
-              <div className="content ops row">
+            <Box>
+              <Flex alignItems="center" mx={-1}>
 
-                <div className="col-1 p-1"  style={colStyle}>
+                <Box width={1/12} px={1}  style={colStyle}>
                   <i className="fas fa-arrow-down"  />
-                </div>
-                <div className="col-5 p-1" style={colStyle}>
+                </Box>
+                <Box width={5/12} px={1} style={colStyle}>
                   <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-                  <div className="input-group">
-                    <div className="input-group-prepend">
-                      <div className="input-group-text">$</div>
-                    </div>
-                    <input type="number" step="0.1" className="form-control" placeholder="0.00" value={this.state.amount}
-                           onChange={event => this.updateState('amount', event.target.value)} />
-                  </div>
+                  <Input type="number" step="0.1" placeholder="0.00" width={1} value={this.state.amount || ''}
+                         onChange={event => this.updateState('amount', event.target.value)} />
                   </Scaler>
-                </div>
-                <div className="col-3 p-1"  style={colStyle}>
+                </Box>
+                <Box width={3/12} px={1}  style={colStyle}>
                   <Scaler config={{startZoomAt:650,origin:"0% 85%"}}>
                   {xdaiCancelButton}
                   </Scaler>
-                </div>
-                <div className="col-3 p-1">
-                  <button className="btn btn-large w-100"  disabled={buttonsDisabled} style={this.props.buttonStyle.primary} onClick={async ()=>{
+                </Box>
+                <Box width={3/12} px={1}>
+                  <Button width={1} disabled={buttonsDisabled} onClick={async ()=>{
 
                     let amountOfxDaiToWithdraw = this.state.xdaiweb3.utils.toWei(""+this.state.amount,'ether')
                     console.log("Using "+this.props.ERC20NAME+" contract to withdraw "+amountOfxDaiToWithdraw+" xDai")
@@ -1069,12 +1056,12 @@ export default class Exchange extends React.Component {
                     <Scaler config={{startZoomAt:600,origin:"10% 50%"}}>
                       <i className="fas fa-arrow-down" /> Send
                     </Scaler>
-                  </button>
+                  </Button>
 
-                </div>
-              </div>
+                </Box>
+              </Flex>
               {extraWithdrawInfo}
-            </div>
+            </Box>
           )
         }
       }else{
@@ -1083,28 +1070,28 @@ export default class Exchange extends React.Component {
 
 
         xdaiToDendaiDisplay = (
-           <div className="content ops row">
+           <Flex alignItems="center" mx={-1}>
 
-             <div className="col-6 p-1">
-               <button className="btn btn-large w-100"  style={this.props.buttonStyle.primary} disabled={buttonsDisabled}  onClick={()=>{
+             <Box width={6/12} px={1}>
+               <Button width={1} disabled={buttonsDisabled} onClick={()=>{
                  this.setState({xdaiToDendaiMode:"deposit"})
                }}>
                   <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
                     <i className="fas fa-arrow-up"  /> xDai to {this.props.ERC20NAME}
                   </Scaler>
-               </button>
-             </div>
+               </Button>
+             </Box>
 
-             <div className="col-6 p-1">
-               <button className="btn btn-large w-100"  style={this.props.buttonStyle.primary} disabled={buttonsDisabled}  onClick={()=>{
+             <Box width={6/12} px={1}>
+               <Button width={1} disabled={buttonsDisabled} onClick={()=>{
                  this.setState({xdaiToDendaiMode:"withdraw"})
                }}>
                  <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
                   <i className="fas fa-arrow-down" /> {this.props.ERC20NAME} to xDai
                  </Scaler>
-               </button>
-             </div>
-           </div>
+               </Button>
+             </Box>
+           </Flex>
         )
       }
 
@@ -1115,33 +1102,33 @@ export default class Exchange extends React.Component {
 
       tokenDisplay = (
         <div>
-          <div className="content ops row" style={{paddingBottom:20}}>
-            <div className="col-2 p-1">
+          <Flex alignItems="center" mx={-1} style={{paddingBottom:20}}>
+            <Box width={2/12} px={1}>
               <a href={link} target="_blank">
                 <img style={logoStyle} src={this.props.ERC20IMAGE} />
               </a>
-            </div>
-            <div className="col-3 p-1" style={{marginTop:8}}>
+            </Box>
+            <Box width={3/12} px={1} style={{marginTop:8}}>
               {this.props.ERC20NAME}
-            </div>
-            <div className="col-5 p-1" style={{marginTop:8,whiteSpace:"nowrap"}}>
+            </Box>
+            <Box width={5/12} px={1} style={{marginTop:8,whiteSpace:"nowrap"}}>
                 <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
                   {this.props.dollarDisplay(this.state.denDaiBalance)}
                 </Scaler>
-            </div>
-            <div className="col-2 p-1" style={{marginTop:8}}>
-              <button className="btn btn-large w-100" disabled={buttonsDisabled} style={this.props.buttonStyle.secondary} onClick={this.props.goBack}>
+            </Box>
+            <Box width={2/12} px={1} style={{marginTop:8}}>
+              <Button width={1} disabled={buttonsDisabled} onClick={this.props.goBack}>
                 <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
                   <i className="fas fa-arrow-right"></i>
                 </Scaler>
-              </button>
-            </div>
+              </Button>
+            </Box>
 
-          </div>
+          </Flex>
 
-          <div className="main-card card w-100">
+          <Card width={1}>
             {xdaiToDendaiDisplay}
-          </div>
+          </Card>
         </div>
       )
     }
@@ -1150,65 +1137,60 @@ export default class Exchange extends React.Component {
     //console.log("daiToXdaiMode",daiToXdaiMode)
     if(daiToXdaiMode=="sending" || daiToXdaiMode=="withdrawing" || daiToXdaiMode=="depositing"){
       daiToXdaiDisplay = (
-        <div className="content ops row" style={{position:"relative"}}>
-          <button style={{width:Math.min(100,this.state.loaderBarPercent)+"%",backgroundColor:this.state.loaderBarColor,color:"#000000"}}
-            className="btn btn-large"
-          >
-          </button>
-          <div style={{position:'absolute',left:"50%",width:"100%",marginLeft:"-50%",fontSize:adjustedFontSize,top:adjustedTop,opacity:0.95,textAlign:"center"}}>
+        <Box position="relative" width={1}>
+          <Box width={Math.min(100, this.state.loaderBarPercent) + '%'} height="32px" bg={this.state.loaderBarColor} />
+          <Box position="absolute" left="50%" width="100%" style={{ marginLeft: '-50%', fontSize: adjustedFontSize, top: adjustedTop, opacity: 0.95, textAlign: 'center' }}>
             {this.state.loaderBarStatusText}
-          </div>
-        </div>
+          </Box>
+        </Box>
       )
 
     }else if(daiToXdaiMode=="deposit"){
       if(!this.state.mainnetMetaAccount && this.props.network!="Mainnet"){
         daiToXdaiDisplay = (
-          <div className="content ops row" style={{textAlign:'center'}}>
-            <div className="col-12 p-1">
+          <Flex alignItems="center" mx={-1} style={{textAlign:'center'}}>
+            <Box width={1} px={1}>
               Error: MetaMask network must be: <span style={{fontWeight:"bold",marginLeft:5}}>Mainnet</span>
               <a href="#" onClick={()=>{this.setState({daiToXdaiMode:false})}} style={{marginLeft:40,color:"#666666"}}>
                 <i className="fas fa-times"/> dismiss
               </a>
-            </div>
-          </div>
+            </Box>
+          </Box>
         )
       }else if(this.props.ethBalance<=0){
         daiToXdaiDisplay = (
-          <div className="content ops row" style={{textAlign:'center'}}>
-            <div className="col-12 p-1">
+          <Flex alignItems="center" mx={-1} style={{textAlign:'center'}}>
+            <Box width={1} px={1}>
               Error: You must have ETH to send DAI.
               <a href="#" onClick={()=>{this.setState({daiToXdaiMode:false})}} style={{marginLeft:40,color:"#666666"}}>
                 <i className="fas fa-times"/> dismiss
               </a>
-            </div>
-          </div>
+            </Box>
+          </Box>
         )
       }else{
         daiToXdaiDisplay = (
-          <div className="content ops row">
-            <div className="col-1 p-1"  style={colStyle}>
+          <Flex alignItems="center" mx={-1}>
+            <Box width={1/12} px={1}  style={colStyle}>
               <i className="fas fa-arrow-up"  />
-            </div>
-            <div className="col-6 p-1" style={colStyle}>
+            </Box>
+            <Box width={6/12} px={1} style={colStyle}>
               <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-              <div className="input-group">
-                <Input
+              <Input
                   width={1}
                   type="number"
                   step="0.1"
                   placeholder="$0.00"
                   value={this.state.amount}
                   onChange={event => this.updateState('amount', event.target.value)} />
-              </div>
               </Scaler>
-            </div>
-            <div className="col-2 p-1"  style={colStyle}>
+            </Box>
+            <Box width={2/12} px={1}  style={colStyle}>
               <Scaler config={{startZoomAt:650,origin:"0% 85%"}}>
               {daiCancelButton}
               </Scaler>
-            </div>
-            <div className="col-3 p-1">
+            </Box>
+            <Box width={3/12} px={1}>
 
               <Button
                 disabled={buttonsDisabled}
@@ -1244,49 +1226,47 @@ export default class Exchange extends React.Component {
                 </Scaler>
               </Button>
 
-            </div>
-          </div>
+            </Box>
+          </Box>
         )
       }
     } else if(daiToXdaiMode=="withdraw"){
       console.log("CHECKING META ACCOUNT ",this.state.xdaiMetaAccount,this.props.network)
       if(!this.state.xdaiMetaAccount && this.props.network!="xDai"){
         daiToXdaiDisplay = (
-          <div className="content ops row" style={{textAlign:'center'}}>
-            <div className="col-12 p-1">
+          <Flex alignItems="center" mx={-1} style={{textAlign:'center'}}>
+            <Box width={1} px={1}>
               Error: MetaMask network must be: <span style={{fontWeight:"bold",marginLeft:5}}>dai.poa.network</span>
               <a href="#" onClick={()=>{this.setState({daiToXdaiMode:false})}} style={{marginLeft:40,color:"#666666"}}>
                 <i className="fas fa-times"/> dismiss
               </a>
-            </div>
-          </div>
+            </Box>
+          </Flex>
         )
       }else{
         daiToXdaiDisplay = (
-          <div className="content ops row">
+          <Flex alignItems="center" mx={-1}>
 
-            <div className="col-1 p-1"  style={colStyle}>
+            <Box width={1/12} px={1}  style={colStyle}>
               <i className="fas fa-arrow-down"  />
-            </div>
-            <div className="col-6 p-1" style={colStyle}>
+            </Box>
+            <Box width={6/12} px={1} style={colStyle}>
               <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-              <div className="input-group">
-                <Input
+              <Input
                   width={1}
                   type="number"
                   step="0.1"
                   placeholder="$0.00"
                   value={this.state.amount}
                   onChange={event => this.updateState('amount', event.target.value)} />
-              </div>
               </Scaler>
-            </div>
-            <div className="col-2 p-1"  style={colStyle}>
+            </Box>
+            <Box width={2/12} px={1}  style={colStyle}>
               <Scaler config={{startZoomAt:650,origin:"0% 85%"}}>
               {daiCancelButton}
               </Scaler>
-            </div>
-            <div className="col-3 p-1">
+            </Box>
+            <Box width={3/12} px={1}>
               <Button disabled={buttonsDisabled} onClick={async ()=>{
                 console.log("AMOUNT:",this.state.amount,"DAI BALANCE:",this.props.daiBalance)
                 this.setState({
@@ -1384,8 +1364,8 @@ export default class Exchange extends React.Component {
                 </Scaler>
               </Button>
 
-            </div>
-          </div>
+            </Box>
+          </Flex>
         )
       }
     } else {
@@ -1414,55 +1394,50 @@ export default class Exchange extends React.Component {
 
     if(ethToDaiMode=="sending" || ethToDaiMode=="depositing" || ethToDaiMode=="withdrawing"){
       ethToDaiDisplay = (
-        <div className="content ops row" style={{position:"relative"}}>
-          <button style={{width:Math.min(100,this.state.loaderBarPercent)+"%",backgroundColor:this.state.loaderBarColor,color:"#000000"}}
-            className="btn btn-large"
-          >
-          </button>
-          <div style={{position:'absolute',left:"50%",width:"100%",marginLeft:"-50%",fontSize:adjustedFontSize,top:adjustedTop,opacity:0.95,textAlign:"center"}}>
+        <Box position="relative" width={1}>
+          <Box width={Math.min(100, this.state.loaderBarPercent) + '%'} height="32px" bg={this.state.loaderBarColor} />
+          <Box position="absolute" left="50%" width="100%" style={{ marginLeft: '-50%', fontSize: adjustedFontSize, top: adjustedTop, opacity: 0.95, textAlign: 'center' }}>
             {this.state.loaderBarStatusText}
-          </div>
-        </div>
+          </Box>
+        </Box>
       )
 
     }else if(ethToDaiMode=="deposit"){
       if(!this.state.mainnetMetaAccount && this.props.network!="Mainnet"){
         ethToDaiDisplay = (
-          <div className="content ops row" style={{textAlign:'center'}}>
-            <div className="col-12 p-1">
+          <Flex alignItems="center" mx={-1} style={{textAlign:'center'}}>
+            <Box width={1} px={1}>
               Error: MetaMask network must be: <span style={{fontWeight:"bold",marginLeft:5}}>Mainnet</span>
               <a href="#" onClick={()=>{this.setState({ethToDaiMode:false})}} style={{marginLeft:40,color:"#666666"}}>
                 <i className="fas fa-times"/> dismiss
               </a>
-            </div>
-          </div>
+            </Box>
+          </Box>
         )
       }else{
         ethToDaiDisplay = (
-          <div className="content ops row">
+          <Flex alignItems="center" mx={-1}>
 
-            <div className="col-1 p-1"  style={colStyle}>
+            <Box width={1/12} px={1}  style={colStyle}>
               <i className="fas fa-arrow-up"  />
-            </div>
-            <div className="col-6 p-1" style={colStyle}>
+            </Box>
+            <Box width={6/12} px={1} style={colStyle}>
               <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-              <div className="input-group">
-                <Input
+              <Input
                   width={1}
                   type="number"
                   step="0.1"
                   placeholder="$0.00"
                   value={this.state.amount}
                   onChange={event => this.updateState('amount', event.target.value)} />
-              </div>
               </Scaler>
-            </div>
-            <div className="col-2 p-1"  style={colStyle}>
+            </Box>
+            <Box width={2/12} px={1}  style={colStyle}>
               <Scaler config={{startZoomAt:650,origin:"0% 85%"}}>
               {ethCancelButton}
               </Scaler>
-            </div>
-            <div className="col-3 p-1">
+            </Box>
+            <Box width={3/12} px={1}>
               <Button disabled={buttonsDisabled} onClick={async ()=>{
 
                 console.log("Using uniswap exchange to move ETH to DAI")
@@ -1541,60 +1516,58 @@ export default class Exchange extends React.Component {
                 </Scaler>
               </Button>
 
-            </div>
-          </div>
+            </Box>
+          </Box>
         )
       }
 
     }else if(ethToDaiMode=="withdraw"){
       if(!this.state.mainnetMetaAccount && this.props.network!="Mainnet"){
         ethToDaiDisplay = (
-          <div className="content ops row" style={{textAlign:'center'}}>
-            <div className="col-12 p-1">
+          <Flex alignItems="center" mx={-1} style={{textAlign:'center'}}>
+            <Box width={1} px={1}>
               Error: MetaMask network must be: <span style={{fontWeight:"bold",marginLeft:5}}>Mainnet</span>
               <a href="#" onClick={()=>{this.setState({ethToDaiMode:false})}} style={{marginLeft:40,color:"#666666"}}>
                 <i className="fas fa-times"/> dismiss
               </a>
-            </div>
-          </div>
+            </Box>
+          </Box>
         )
       }else if(this.props.ethBalance<=0){
         ethToDaiDisplay = (
-          <div className="content ops row" style={{textAlign:'center'}}>
-            <div className="col-12 p-1">
+          <Flex alignItems="center" mx={-1} style={{textAlign:'center'}}>
+            <Box width={1} px={1}>
               Error: You must have ETH to send DAI.
               <a href="#" onClick={()=>{this.setState({ethToDaiMode:false})}} style={{marginLeft:40,color:"#666666"}}>
                 <i className="fas fa-times"/> dismiss
               </a>
-            </div>
-          </div>
+            </Box>
+          </Flex>
         )
       }else{
         ethToDaiDisplay = (
-          <div className="content ops row">
+          <Flex alignItems="center" mx={-1}>
 
-            <div className="col-1 p-1"  style={colStyle}>
+            <Box width={1/12} px={1}  style={colStyle}>
               <i className="fas fa-arrow-down"  />
-            </div>
-            <div className="col-6 p-1" style={colStyle}>
+            </Box>
+            <Box width={6/12} px={1} style={colStyle}>
               <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-              <div className="input-group">
-                <Input
+              <Input
                   width={1}
                   type="number"
                   step="0.1"
                   placeholder="$0.00"
                   value={this.state.amount}
                   onChange={event => this.updateState('amount', event.target.value)} />
-              </div>
               </Scaler>
-            </div>
-            <div className="col-2 p-1"  style={colStyle}>
+            </Box>
+            <Box width={2/12} px={1}  style={colStyle}>
               <Scaler config={{startZoomAt:650,origin:"0% 85%"}}>
               {ethCancelButton}
               </Scaler>
-            </div>
-            <div className="col-3 p-1">
+            </Box>
+            <Box width={3/12} px={1}>
               <Button disabled={buttonsDisabled} onClick={async ()=>{
 
                 console.log("Using uniswap exchange to move DAI to ETH")
@@ -1873,8 +1846,8 @@ export default class Exchange extends React.Component {
                   <i className="fas fa-arrow-down" /> Send
                 </Scaler>
               </Button>
-            </div>
-          </div>
+            </Box>
+          </Flex>
         )
       }
 
@@ -1936,7 +1909,7 @@ export default class Exchange extends React.Component {
           </Field>
           <div>
             { this.state.daiSendToAddress && this.state.daiSendToAddress.length==42 && <Blockies seed={this.state.daiSendToAddress.toLowerCase()} scale={10} /> }
-          </div>
+          </Box>
           <Field label={'Send Amount'} mb={3}>
             <Flex>
               <Input
@@ -1972,13 +1945,13 @@ export default class Exchange extends React.Component {
         </Box>
       )
       sendDaiButton = (
-        <button className="btn btn-large w-100" style={{backgroundColor:"#888888",whiteSpace:"nowrap"}} onClick={()=>{
+        <Button width={1} style={{backgroundColor:"#888888",whiteSpace:"nowrap"}} onClick={()=>{
           this.setState({sendDai:false})
         }}>
           <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
             <i className="fas fa-times"></i>
           </Scaler>
-        </button>
+        </Button>
       )
     }
 
@@ -1997,8 +1970,9 @@ export default class Exchange extends React.Component {
     )
 
     let fundByWyreButton = (
-      <button
-        className="btn btn-large w-100 wyre-button--font-size"
+      <Button
+        width={1}
+        className="wyre-button--font-size"
         disabled={buttonsDisabled}
         style={
             Object.assign({}, this.props.buttonStyle.secondary, {
@@ -2027,9 +2001,9 @@ export default class Exchange extends React.Component {
                     </span>
                     <span>Loading...</span>
                 </>) : `Buy $${this.state.wyreFundAmount}`}
-        </div>
+        </Flex>
         </Scaler>
-      </button>
+      </Button>
     )
 
 
@@ -2054,7 +2028,7 @@ export default class Exchange extends React.Component {
           </Field>
           <div>
             { this.state.ethSendToAddress && this.state.ethSendToAddress.length==42 && <Blockies seed={this.state.ethSendToAddress.toLowerCase()} scale={10} /> }
-          </div>
+          </Box>
           <Field label={'Send Amount'} mb={3}>
             <Flex>
               <Input
@@ -2108,13 +2082,13 @@ export default class Exchange extends React.Component {
         </Box>
       )
       sendEthButton = (
-        <button className="btn btn-large w-100" style={{backgroundColor:"#888888",whiteSpace:"nowrap"}} onClick={()=>{
+        <Button width={1} style={{backgroundColor:"#888888",whiteSpace:"nowrap"}} onClick={()=>{
           this.setState({sendEth:false})
         }}>
           <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
             <i className="fas fa-times"></i>
           </Scaler>
-        </button>
+        </Button>
       )
     }
 
@@ -2155,7 +2129,7 @@ export default class Exchange extends React.Component {
           <Field label={'To Address'} mb={3}>
             <Input
               type="text"
-              className="form-control"
+             
               placeholder="0x..."
               value={this.state.xdaiSendToAddress}
               onChange={event => this.updateState('xdaiSendToAddress', event.target.value)}
@@ -2163,13 +2137,13 @@ export default class Exchange extends React.Component {
           </Field>
           <div>
             { this.state.xdaiSendToAddress && this.state.xdaiSendToAddress.length==42 && <Blockies seed={this.state.xdaiSendToAddress.toLowerCase()} scale={10} /> }
-          </div>
+          </Box>
           <Field label={'Send Amount'} mb={3}>
             <Flex>
               <Input
                 type="number"
                 step="0.1"
-                className="form-control"
+               
                 placeholder="$0.00"
                 value={this.state.xdaiSendAmount}
                 onChange={event => this.updateState('xdaiSendAmount', event.target.value)}
@@ -2193,13 +2167,13 @@ export default class Exchange extends React.Component {
         </Box>
       )
       sendXdaiButton = (
-        <button className="btn btn-large w-100" style={{backgroundColor:"#888888",whiteSpace:"nowrap"}} onClick={()=>{
+        <Button width={1} style={{backgroundColor:"#888888",whiteSpace:"nowrap"}} onClick={()=>{
           this.setState({sendXdai:false})
         }}>
           <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
             <i className="fas fa-times"></i>
           </Scaler>
-        </button>
+        </Button>
       )
     }
 
@@ -2210,99 +2184,84 @@ export default class Exchange extends React.Component {
         {tokenDisplay}
 
 
-          <div className="content ops row" style={{paddingBottom:20}}>
-            <div className="col-2 p-1">
+          <Flex alignItems="center" mx={-1} style={{paddingBottom:20}}>
+            <Box width={2/12} px={1}>
               <img style={logoStyle} src={this.props.xdai} />
-            </div>
-            <div className="col-3 p-1" style={{marginTop:8}}>
+            </Box>
+            <Box width={3/12} px={1} style={{marginTop:8}}>
               xDai
-            </div>
-            <div className="col-4 p-1" style={{marginTop:8,whiteSpace:"nowrap"}}>
+            </Box>
+            <Box width={4/12} px={1} style={{marginTop:8,whiteSpace:"nowrap"}}>
                 <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
                   {this.props.dollarDisplay(this.props.xdaiBalance)}
                 </Scaler>
-            </div>
-            <div className="col-3 p-1" style={{marginTop:8}}>
+            </Box>
+            <Box width={3/12} px={1} style={{marginTop:8}}>
               {sendXdaiButton}
-            </div>
+            </Box>
 
-          </div>
+          </Box>
           {sendXdaiRow}
 
-        <div className="main-card card w-100">
+        <Card width={1}>
           {daiToXdaiDisplay}
-        </div>
+        </Flex>
 
 
 
-          <div className="content ops row" style={{paddingBottom:20}}>
-            <div className="col-2 p-1">
+          <Flex alignItems="center" mx={-1} style={{paddingBottom:20}}>
+            <Box width={2/12} px={1}>
               <img style={logoStyle} src={this.props.dai} />
-            </div>
-            <div className="col-3 p-1" style={{marginTop:9}}>
+            </Box>
+            <Box width={3/12} px={1} style={{marginTop:9}}>
               DAI
-            </div>
-            <div className="col-4 p-1" style={{marginTop:9,whiteSpace:"nowrap"}}>
+            </Box>
+            <Box width={4/12} px={1} style={{marginTop:9,whiteSpace:"nowrap"}}>
               <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
                 {this.props.dollarDisplay(this.props.daiBalance)}
               </Scaler>
-            </div>
-            <div className="col-3 p-1" style={{marginTop:8}}>
+            </Box>
+            <Box width={3/12} px={1} style={{marginTop:8}}>
               {sendDaiButton}
-            </div>
-          </div>
+            </Box>
+          </Flex>
           {sendDaiRow}
 
 
-        <div className="main-card card w-100">
+        <Card width={1}>
           {ethToDaiDisplay}
-        </div>
+        </Flex>
 
 
-          <div className="content ops row" style={{paddingBottom:20}}>
-            <div className="col-2 p-1">
+          <Flex alignItems="center" mx={-1} style={{paddingBottom:20}}>
+            <Box width={2/12} px={1}>
               <img style={logoStyle} src={this.props.eth} />
-            </div>
-            <div className="col-3 p-1" style={{marginTop:10}}>
+            </Box>
+            <Box width={3/12} px={1} style={{marginTop:10}}>
               ETH
-            </div>
-            <div className="col-4 p-1" style={{marginTop:10,whiteSpace:"nowrap"}}>
+            </Box>
+            <Box width={4/12} px={1} style={{marginTop:10,whiteSpace:"nowrap"}}>
               <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
                 {this.props.dollarDisplay(this.props.ethBalance*this.props.ethprice)}
               </Scaler>
-            </div>
-            <div className="col-3 p-1" style={{marginTop:8}}>
+            </Box>
+            <Box width={3/12} px={1} style={{marginTop:8}}>
               {sendEthButton}
-            </div>
-          </div>
+            </Box>
+          </Flex>
 
 
           { (window.location.hostname.indexOf("localhost") >= 0 || window.location.hostname.indexOf("wyre.xdai.io") >= 0 || window.location.hostname.indexOf("s.xdai.io") >= 0) && (
-            <div className="send-to-address card w-100" style={{marginTop:20,borderBottom:0,paddingTop:50}}>
-              <div className="content ops row">
-                <div className="col-2 p-1">
+            <Card width={1} style={{marginTop:20,borderBottom:0,paddingTop:50}}>
+              <Flex alignItems="center" mx={-1}>
+                <Box width={2/12} px={1}>
                   <img style={logoStyle} src={wyrelogo} />
-                </div>
-                <div className="col-2 p-1" style={{marginTop:10}}>
+                </Box>
+                <Box width={2/12} px={1} style={{marginTop:10}}>
                   Wyre
-                </div>
-                <div className="col-5 p-1" style={{whiteSpace:"nowrap"}}>
-                    {/*<div className="input-group">
-                        <div className="input-group-prepend">
-                            <div className="input-group-text">$</div>
-                        </div>
-                        <input
-                            type="number"
-                            step="0.1"
-                            className="form-control"
-                            placeholder="0.00"
-                            value={this.state.wyreFundAmount}
-                            onChange={event =>
-                                this.updateState('wyreFundAmount', event.target.value)
-                            }
-                        />
-                    </div>*/}
-                    <div className="wyre-slider" style={{padding: '0 20px', display: 'flex', alignItems: 'center', paddingTop: '15px',}}>
+                </Box>
+                <Box width={5/12} px={1} style={{whiteSpace:"nowrap"}}>
+                    <div className="wyre-slider" style={{padding: '0 20px', display: 'flex', alignItems: 'center', paddingTop: '15px'}}>
                     <InputRange
                         maxValue={25}
                         minValue={5}
@@ -2314,12 +2273,12 @@ export default class Exchange extends React.Component {
                         }
                     />
                     </div>
-                </div>
-                <div className="col-3 p-1" style={{marginTop:8}}>
+                </Box>
+                <Box width={3/12} px={1} style={{marginTop:8}}>
                   {fundByWyreButton}
-                </div>
-              </div>
-            </div>
+                </Box>
+              </Flex>
+            </Card>
           )}
 
 

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,11 +1,34 @@
 import React from 'react';
+import { Box, Text } from 'rimble-ui';
 
-export default ({alert, changeAlert}) => {
+const alertColors = {
+  success: { bg: '#e6f7ee', color: '#1a7f4b' },
+  warning: { bg: '#fff8e6', color: '#9a6b00' },
+  danger: { bg: '#fdecea', color: '#b42318' },
+  info: { bg: '#eef4ff', color: '#175cd3' },
+};
+
+export default ({ alert, changeAlert }) => {
+  const palette = alertColors[alert.type] || alertColors.info;
+
   return (
-    <div style={{zIndex:2}} className="footer text-center" onClick={() => changeAlert(null)}>
-      <div className={`alert alert-${alert.type}`}>
-        {alert.message}
-      </div>
-    </div>
-  )
+    <Box
+      style={{ zIndex: 2, cursor: 'pointer' }}
+      className="footer"
+      onClick={() => changeAlert(null)}
+      textAlign="center"
+      p={3}
+    >
+      <Box
+        bg={palette.bg}
+        color={palette.color}
+        p={3}
+        borderRadius={2}
+        display="inline-block"
+        maxWidth="90%"
+      >
+        <Text fontSize={2}>{alert.message}</Text>
+      </Box>
+    </Box>
+  );
 };

--- a/src/components/History.js
+++ b/src/components/History.js
@@ -8,6 +8,12 @@ import {toArray} from 'react-emoji-render';
 import Ruler from "./Ruler";
 import {CopyToClipboard} from "react-copy-to-clipboard";
 import i18next from 'i18next';
+import {
+  Box,
+  Button,
+  Flex,
+  Input
+} from 'rimble-ui';
 const QRCode = require('qrcode.react');
 const Transaction = require("ethereumjs-tx")
 const EthUtil = require('ethereumjs-util')
@@ -284,196 +290,154 @@ export default class History extends React.Component {
       }
     }
 
-    let sendChatButton = ""
-    let sendFundsButton = ""
-    if(this.state.sendingChat){
+    let sendChatButton;
+    if (this.state.sendingChat) {
       sendChatButton = (
-        <button className="btn btn-large w-100" style={{whiteSpace:"nowrap",backgroundColor:"#666666"}}>
-          <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-            <i className="fas fa-cog fa-spin"></i>
+        <Button width={1} disabled>
+          <Scaler config={{ startZoomAt: 400, origin: "50% 50%" }}>
+            <i className="fas fa-cog fa-spin" />
           </Scaler>
-        </button>
-      )
-      sendFundsButton = (
-        <button className="btn btn-large w-100" style={{whiteSpace:"nowrap",backgroundColor:"#666666"}}>
-          <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-            <i className="fas fa-cog fa-spin"></i>
-          </Scaler>
-        </button>
-      )
-    }else{
+        </Button>
+      );
+    } else {
       sendChatButton = (
-        <button className="btn btn-large w-100" style={buttonStyle.primary}
-                onClick={this.sendChat.bind(this)}>
-          <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-            <i className="fas fa-comment"/>
-          </Scaler>
-        </button>
-      )
-      sendFundsButton = (
-        <button className="btn btn-large w-100" style={buttonStyle.secondary}
-                onClick={this.sendChat.bind(this)}>
-          <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-            <i className="fas fa-comment"/>
-          </Scaler>
-        </button>
-      )
+        <Button width={1} icon="Chat" onClick={this.sendChat.bind(this)} />
+      );
     }
 
-
-    let waveButton = ""
-    if(this.state.waving){
+    let waveButton;
+    if (this.state.waving) {
       waveButton = (
-        <button className="btn btn-large w-100" style={{whiteSpace:"nowrap",backgroundColor:"#666666"}}>
-          <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-            <i className="fas fa-cog fa-spin"></i>
+        <Button width={1} disabled>
+          <Scaler config={{ startZoomAt: 400, origin: "50% 50%" }}>
+            <i className="fas fa-cog fa-spin" />
           </Scaler>
-        </button>
-      )
-    }else if(this.props.metaAccount){
+        </Button>
+      );
+    } else if (this.props.metaAccount) {
       waveButton = (
-        <button className="btn btn-large w-100" style={buttonStyle.primary}
-                onClick={()=>{
-                  this.setState({waving:true})
-                  this.props.send(this.props.target, 0, 120000, this.props.web3.utils.utf8ToHex(":wave:"), (result) => {
-                    if(result && result.transactionHash){
-                      this.setState({waving:false})
-                    }
-                  })
-                }}>
-          <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-            <i className="fas fa-handshake"/> {i18next.t('history.wave')}
+        <Button
+          width={1}
+          onClick={() => {
+            this.setState({ waving: true });
+            this.props.send(this.props.target, 0, 120000, this.props.web3.utils.utf8ToHex(":wave:"), (result) => {
+              if (result && result.transactionHash) {
+                this.setState({ waving: false });
+              }
+            });
+          }}
+        >
+          <Scaler config={{ startZoomAt: 400, origin: "50% 50%" }}>
+            <i className="fas fa-handshake" /> {i18next.t('history.wave')}
           </Scaler>
-        </button>
-      )
-    }else{
+        </Button>
+      );
+    } else {
       waveButton = (
-        <button className="btn btn-large w-100" style={{whiteSpace:"nowrap",backgroundColor:"#aaaaaa"}}
-                onClick={()=>{
-                  this.props.changeAlert({type: 'warning', message: i18next.t('history.metamask_error')})
-                }}>
-          <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-            <i className="fas fa-handshake"/> {i18next.t('history.wave')}
+        <Button
+          width={1}
+          bg="#aaaaaa"
+          onClick={() => {
+            this.props.changeAlert({ type: 'warning', message: i18next.t('history.metamask_error') });
+          }}
+        >
+          <Scaler config={{ startZoomAt: 400, origin: "50% 50%" }}>
+            <i className="fas fa-handshake" /> {i18next.t('history.wave')}
           </Scaler>
-        </button>
-      )
+        </Button>
+      );
     }
 
-    /*
-    <div className="col-3 p-1">
-      <button className="btn btn-large w-100" style={{whiteSpace:"nowrap"}}
-              onClick={()=>{
-                window.location = "/"+target
-              }}>
-        <Scaler config={{startZoomAt:600,origin:"10% 50%"}}>
-          <i className="fas fa-money-bill-wave"/> Send
-        </Scaler>
-      </button>
-    </div>
-     */
-    let sendForm
-
-    let placeholder="unencrypted public chat..."
-    if(this.state["publicKey_"+target]){
-      placeholder = "encrypted chat..."
+    let sendForm;
+    let placeholder = "unencrypted public chat...";
+    if (this.state["publicKey_" + target]) {
+      placeholder = "encrypted chat...";
     }
 
     let chatInput = (
-      <input disabled={this.state.sendingChat} type="text" className="form-control" placeholder={placeholder} value={this.state.newChat}
+      <Input
+        disabled={this.state.sendingChat}
+        type="text"
+        placeholder={placeholder}
+        value={this.state.newChat || ''}
         ref={(input) => { this.nameInput = input; }}
         onKeyDown={this.onKeyDown}
-        onChange={event => this.setState({newChat:event.target.value})}
+        onChange={event => this.setState({ newChat: event.target.value })}
       />
-    )
+    );
 
-    if(this.state.sendingFunds){
+    if (this.state.sendingFunds) {
       sendForm = (
-        <div className="content ops row">
-          <div className="col-4 p-1">
-            <div className="input-group">
-              <div className="input-group-prepend" onClick={()=>{
-                  this.setState({sendingFunds:false},()=>{
-                    setTimeout(()=>{
-                      this.nameInput.focus();
-                    },250)
-                  })
-              }}>
-                <div className="input-group-text">$</div>
-              </div>
-              <input type="number" step="0.1" onKeyDown={this.onKeyDown} className="form-control" placeholder="0.00" value={this.state.newChatAmount}
-                ref={(input) => { this.amountInput = input; }}
-                     onChange={event => this.setState({newChatAmount:event.target.value})}
-              />
-            </div>
-          </div>
-          <div className="col-6 p-1">
-            {chatInput}
-          </div>
-          <div className="col-2 p-1">
-            {sendChatButton}
-          </div>
-        </div>
-      )
-    }else{
+        <Flex alignItems="center" mx={-1}>
+          <Box width={4 / 12} px={1}>
+            <Input
+              type="number"
+              step="0.1"
+              onKeyDown={this.onKeyDown}
+              placeholder="0.00"
+              value={this.state.newChatAmount || ''}
+              ref={(input) => { this.amountInput = input; }}
+              onChange={event => this.setState({ newChatAmount: event.target.value })}
+              onClick={() => {
+                this.setState({ sendingFunds: false }, () => {
+                  setTimeout(() => { this.nameInput.focus(); }, 250);
+                });
+              }}
+            />
+          </Box>
+          <Box width={6 / 12} px={1}>{chatInput}</Box>
+          <Box width={2 / 12} px={1}>{sendChatButton}</Box>
+        </Flex>
+      );
+    } else {
       sendForm = (
-        <div className="content ops row">
-          <div className="col-2 p-1">
-            <button className="btn btn-large w-100" style={buttonStyle.secondary}
-              onClick={()=>{
-                this.setState({sendingFunds:true},()=>{
-                  setTimeout(()=>{
-                    this.amountInput.focus();
-                  },250)
-                })
-              }}>
-              <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-                <i className="fas fa-money-bill-wave"/>
-              </Scaler>
-            </button>
-          </div>
-          <div className="col-8 p-1">
-           {chatInput}
-          </div>
-          <div className="col-2 p-1">
-            {sendChatButton}
-          </div>
-        </div>
-      )
+        <Flex alignItems="center" mx={-1}>
+          <Box width={2 / 12} px={1}>
+            <Button
+              width={1}
+              icon="AttachMoney"
+              onClick={() => {
+                this.setState({ sendingFunds: true }, () => {
+                  setTimeout(() => { this.amountInput.focus(); }, 250);
+                });
+              }}
+            />
+          </Box>
+          <Box width={8 / 12} px={1}>{chatInput}</Box>
+          <Box width={2 / 12} px={1}>{sendChatButton}</Box>
+        </Flex>
+      );
     }
 
-    let isEncrypted = ""
-    if(this.state["publicKey_"+target]){
+    let isEncrypted = "";
+    if (this.state["publicKey_" + target]) {
       isEncrypted = (
-        <i className="fa fa-lock" style={{fontSize:30,opacity:0.8,position:'absolute',left:50,top:10}} aria-hidden="true"></i>
-      )
+        <i className="fa fa-lock" style={{ fontSize: 30, opacity: 0.8, position: 'absolute', left: 50, top: 10 }} aria-hidden="true" />
+      );
     }
 
     return (
-      <div style={{marginTop:20}}>
-          <div className="content ops row">
-            <div className="col-2 p-1">
-              <a href={"https://blockscout.com/poa/dai/address/"+target+"/transactions"} target="_blank">
-                <Blockies seed={target} scale={5}/> {isEncrypted}
-              </a>
-            </div>
-
-            <div className="col-4 p-1">
-              <CopyToClipboard text={target}>
-                <button className="btn btn-large w-100" style={buttonStyle.secondary}
-                  onClick={() => this.props.changeAlert({type: 'success', message: target+' copied to clipboard'})}>
-                  <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-                    <i className="fas fa-save"/> Copy
-                  </Scaler>
-                </button>
-              </CopyToClipboard>
-            </div>
-            <div className="col-2 p-1">
-            </div>
-            <div className="col-4 p-1">
-              {waveButton}
-            </div>
-
-          </div>
+      <Box mt={4}>
+        <Flex alignItems="center" mx={-1} mb={3}>
+          <Box width={2 / 12} px={1}>
+            <a href={"https://blockscout.com/poa/dai/address/" + target + "/transactions"} target="_blank" rel="noopener noreferrer">
+              <Blockies seed={target} scale={5} /> {isEncrypted}
+            </a>
+          </Box>
+          <Box width={4 / 12} px={1}>
+            <CopyToClipboard text={target}>
+              <Button
+                width={1}
+                icon="Save"
+                onClick={() => this.props.changeAlert({ type: 'success', message: target + ' copied to clipboard' })}
+              >
+                Copy
+              </Button>
+            </CopyToClipboard>
+          </Box>
+          <Box width={2 / 12} px={1} />
+          <Box width={4 / 12} px={1}>{waveButton}</Box>
+        </Flex>
 
         {txns}
 
@@ -481,10 +445,8 @@ export default class History extends React.Component {
 
         <div name="sendForm"></div>
         {sendForm}
-
-
-      </div>
-    )
+      </Box>
+    );
   }
 }
 

--- a/src/components/History.js
+++ b/src/components/History.js
@@ -202,7 +202,7 @@ export default class History extends React.Component {
           txns.push(
             <div style={{paddingTop:10,paddingBottom:10}}>
               <Ruler />
-              <div className="content ops row" style={{position:"relative"}}>
+              <Box style={{ position: "relative" }}>
                 <div style={{position:'absolute',right:0,top:-13,opacity:0.5,fontSize:12}}>
                   {isEncrypted} {cleanTime((block-theseTransactionsByAddress[r].blockNumber)*5)} ago
                 </div>
@@ -217,14 +217,14 @@ export default class History extends React.Component {
                   </Linkify>
                 </div>
                 {messageValue}
-              </div>
+              </Box>
             </div>
           )
         }else{
           txns.push(
             <div key={"tx"+r} style={{paddingTop:3,paddingBottom:21}}>
               <Ruler />
-              <div className="content ops row" style={{position:"relative",paddingTop:3}}>
+              <Box style={{ position: "relative", paddingTop: 3 }}>
                 <div style={{position:'absolute',right:0,top:6,opacity:0.5,fontSize:12}}>
                   {cleanTime((block-theseTransactionsByAddress[r].blockNumber)*5)} ago
                 </div>
@@ -234,7 +234,7 @@ export default class History extends React.Component {
                 <div style={{position:'absolute',left:0}}>
                   <Blockies seed={theseTransactionsByAddress[r].from} scale={3}/>
                 </div>
-              </div>
+              </Box>
             </div>
           )
         }
@@ -251,7 +251,7 @@ export default class History extends React.Component {
           txns.push(
             <div key={"tx"+r} style={{paddingTop:10,paddingBottom:10}}>
               <Ruler />
-              <div className="content ops row" style={{position:"relative"}}>
+              <Box style={{ position: "relative" }}>
                 <div style={{position:'absolute',left:0,top:-13,opacity:0.5,fontSize:12}}>
                   {isEncrypted} {cleanTime((block-theseTransactionsByAddress[r].blockNumber)*5)} ago
                 </div>
@@ -266,14 +266,14 @@ export default class History extends React.Component {
                   </Linkify>
                 </div>
                 {messageValue}
-              </div>
+              </Box>
             </div>
           )
         }else{
           txns.push(
             <div key={"tx"+r} style={{paddingTop:3,paddingBottom:21}}>
               <Ruler />
-              <div className="content ops row" style={{position:"relative",paddingTop:3}}>
+              <Box style={{ position: "relative", paddingTop: 3 }}>
                 <div style={{position:'absolute',left:0,top:6,opacity:0.5,fontSize:12}}>
                   {cleanTime((block-theseTransactionsByAddress[r].blockNumber)*5)} ago
                 </div>
@@ -283,7 +283,7 @@ export default class History extends React.Component {
                 <div style={{position:'absolute',right:0}}>
                   <Blockies seed={theseTransactionsByAddress[r].from} scale={3}/>
                 </div>
-              </div>
+              </Box>
             </div>
           )
         }

--- a/src/components/Receipt.js
+++ b/src/components/Receipt.js
@@ -1,40 +1,28 @@
 import React from 'react';
-import Ruler from "./Ruler";
 import Badge from './Badge';
-import Balance from "./Balance";
-import {CopyToClipboard} from "react-copy-to-clipboard";
 import { Blockie } from "dapparatus";
-import RecentTransactions from './RecentTransactions';
-import { scroller } from 'react-scroll'
 import i18n from '../i18n';
 import axios from 'axios';
-const QRCode = require('qrcode.react');
+import {
+  Box,
+  Flex,
+  Icon,
+  Link,
+  Text
+} from 'rimble-ui';
 
+const BockieSize = 12;
 
-const BockieSize = 12
-
-export default class Receive extends React.Component {
-
-  constructor(props) {
-    super(props);
-    let initialState = {
+export default class Receipt extends React.Component {
+  componentDidMount() {
+    if (this.props.receipt && this.props.receipt.daiposOrderId) {
+      let url = "https://us-central1-daipos.cloudfunctions.net/transactionBuffer?orderId="
+        + this.props.receipt.daiposOrderId
+        + "&txHash=" + this.props.receipt.result.transactionHash
+        + "&networkId=100";
+      axios.get(url);
     }
-  }
-  componentDidMount(){
-    console.log("RECEIPT LOADED",this.props)
-    if(this.props.receipt && this.props.receipt.daiposOrderId){
-      console.log("This was a daipos Order... ping their server for them...")
-      // https://us-central1-daipos.cloudfunctions.net/transactionBuffer?orderId=0JFmycULnk9kAboK5ESg&txHash=0x8c831cd5cbc8786982817e43a0a77627ad0b12eaa92feff97fb3b7e91c263b1c&networkId=100
-      let url = "https://us-central1-daipos.cloudfunctions.net/transactionBuffer?orderId="+this.props.receipt.daiposOrderId+"&txHash="+this.props.receipt.result.transactionHash+"&networkId=100"
-      console.log("url:",url)
-      axios.get(url)
-       .then((response)=>{
-         console.log("Finished hitting the Ching servers:",response)
-       })
-    }
-    console.log("CHECKING PARAMS:",this.props.receipt.params)
-    if(this.props.receipt && this.props.receipt.params && this.props.receipt.params.callback){
-      console.log("Redirecting to ",this.props.receipt.params.callback,"with data:",this.props.receipt)
+    if (this.props.receipt && this.props.receipt.params && this.props.receipt.params.callback) {
       let returnObject = {
         to: this.props.receipt.to,
         from: this.props.receipt.from,
@@ -42,80 +30,61 @@ export default class Receive extends React.Component {
         transactionHash: this.props.receipt.result.transactionHash,
         status: this.props.receipt.result.status,
         data: this.props.receipt.result.v,
-      }
-      console.log("returnObject",returnObject)
-      setTimeout(()=>{
-        window.location = this.props.receipt.params.callback+"?receipt="+(encodeURI(JSON.stringify(returnObject)))
-      },2500)
+      };
+      setTimeout(() => {
+        window.location = this.props.receipt.params.callback + "?receipt=" + (encodeURI(JSON.stringify(returnObject)));
+      }, 2500);
     }
   }
+
   render() {
-    let {receipt,buttonStyle,ERC20TOKEN,address, balance, changeView, dollarDisplay,account} = this.props
+    let { receipt, dollarDisplay } = this.props;
 
-    let message = ""
-
-    let sendAmount = ""
-    if(receipt.badge){
+    let sendAmount;
+    if (receipt.badge) {
       sendAmount = (
-        <div>
-          <Badge key={"sentbadge"} id={receipt.badge.id} image={receipt.badge.image}/>
-        </div>
-      )
-    }else{
+        <Badge key="sentbadge" id={receipt.badge.id} image={receipt.badge.image} />
+      );
+    } else {
       sendAmount = (
-        <div>
-          <span style={{opacity:0.15}}>-</span>{dollarDisplay(receipt.amount)}<span style={{opacity:0.15}}>-></span>
-        </div>
-      )
-    }
-
-    if(receipt.message){
-      message = (
-        <div className="row" style={{cursor:"pointer",width:"100%",marginTop:20,marginBottom:-30}}>
-          <div className="col-12" style={{textAlign:'center',whiteSpace:"nowrap",letterSpacing:-1,padddingTop:30,fontSize:20}}>
-            {receipt.message}
-          </div>
-        </div>
-      )
+        <Text fontSize={5} pt={4}>
+          <span style={{ opacity: 0.15 }}>-</span>
+          {dollarDisplay(receipt.amount)}
+          <span style={{ opacity: 0.15 }}>-&gt;</span>
+        </Text>
+      );
     }
 
     return (
-      <div>
-        <div className="send-to-address w-100">
-            <div className="row" style={{cursor:"pointer",width:"100%"}}>
-              <div className="col-12" style={{textAlign:'center',whiteSpace:"nowrap",letterSpacing:-1}}>
-                <i className="fas fa-check-circle" style={{color:"#39e917",fontSize:180,opacity:.7}}></i>
-              </div>
-            </div>
+      <Box>
+        <Flex flexDirection="column" alignItems="center" width={1}>
+          <Icon name="CheckCircle" color="#39e917" size={96} style={{ opacity: 0.7 }} />
+        </Flex>
 
-            <div className="row" style={{cursor:"pointer",width:"100%"}}>
-              <div className="col-4" style={{textAlign:'center',whiteSpace:"nowrap",letterSpacing:-1}}>
-                <Blockie
-                  address={receipt.from}
-                  config={{size:BockieSize}}
-                />
-              </div>
-              <div className="col-4" style={{textAlign:'center',whiteSpace:"nowrap",letterSpacing:-1,fontSize:25,paddingTop:28}}>
-                {sendAmount}
-              </div>
-              <div className="col-4" style={{textAlign:'center',whiteSpace:"nowrap",letterSpacing:-1}}>
-                <Blockie
-                  address={receipt.to}
-                  config={{size:BockieSize}}
-                />
-              </div>
-            </div>
-            {message}
+        <Flex alignItems="center" justifyContent="space-between" width={1} mt={4}>
+          <Box width={1 / 3} textAlign="center">
+            <Blockie address={receipt.from} config={{ size: BockieSize }} />
+          </Box>
+          <Box width={1 / 3} textAlign="center">
+            {sendAmount}
+          </Box>
+          <Box width={1 / 3} textAlign="center">
+            <Blockie address={receipt.to} config={{ size: BockieSize }} />
+          </Box>
+        </Flex>
 
-        </div>
-        <div name="theVeryBottom" className="text-center bottom-text">
-          <span style={{padding:10}}>
-            <a href="#" style={{color:"#FFFFFF"}} onClick={()=>{this.props.goBack()}}>
-              <i className="fas fa-times"/> {i18n.t('done')}
-            </a>
-          </span>
-        </div>
-      </div>
-    )
+        {receipt.message && (
+          <Text textAlign="center" mt={4} fontSize={4}>
+            {receipt.message}
+          </Text>
+        )}
+
+        <Box name="theVeryBottom" textAlign="center" className="bottom-text" mt={4}>
+          <Link color="#FFFFFF" onClick={() => { this.props.goBack(); }}>
+            <Icon name="Close" /> {i18n.t('done')}
+          </Link>
+        </Box>
+      </Box>
+    );
   }
 }

--- a/src/components/RecentTransactions.js
+++ b/src/components/RecentTransactions.js
@@ -2,182 +2,146 @@ import React from 'react';
 import { Blockie } from "dapparatus";
 import Ruler from "./Ruler";
 import { Scaler } from "dapparatus";
-import { Flex, Text, Image } from "rimble-ui";
+import { Box, Button, Flex, Icon, Text } from "rimble-ui";
 
-export default ({dollarDisplay, view, max, buttonStyle, ERC20TOKEN, vendorName, address, recentTxs, block, changeView}) => {
-  let txns = []
-  let count=0
-  if(!max) max=9999
-  for(let r in recentTxs){
-    let thisValue = parseFloat(recentTxs[r].value)
-    if(thisValue>0.0){
+export default ({ dollarDisplay, view, max, buttonStyle, ERC20TOKEN, address, recentTxs, block, changeView }) => {
+  let txns = [];
+  let count = 0;
+  if (!max) max = 9999;
 
-      let extraUp = 0
-      if(view=="receive"){
-        extraUp=-10
-      }
-      let extraIcon = ""
-      if(recentTxs[r].data){
-        extraIcon = (
-          <div style={{position:'absolute',right:-3,top:extraUp}}>
-            <button className="btn btn-large w-100" style={buttonStyle.primary}>
-              <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-                <i className="fas fa-comment"></i>
-              </Scaler>
-            </button>
-          </div>
-        )
-      }else{
-        extraIcon = (
-          <div style={{position:'absolute',right:-3,top:extraUp}}>
-            <button className="btn btn-large w-100" style={buttonStyle.secondary}>
-              <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-                <i className="fas fa-comment"></i>
-              </Scaler>
-            </button>
-          </div>
-        )
-      }
+  for (let r in recentTxs) {
+    let thisValue = parseFloat(recentTxs[r].value);
+    if (thisValue > 0.0) {
+      let extraUp = view === "receive" ? -10 : 0;
+      let extraIcon = (
+        <Box position="absolute" right={-3} top={extraUp}>
+          <Button
+            icon="Chat"
+            width={1}
+            style={recentTxs[r].data ? buttonStyle.primary : buttonStyle.secondary}
+          />
+        </Box>
+      );
 
-      let dollarView
-      if(ERC20TOKEN){
-        if(recentTxs[r].token){
+      let dollarView;
+      if (ERC20TOKEN) {
+        if (recentTxs[r].token) {
           dollarView = (
             <span>
-              <span style={{opacity:0.33}}>-</span>{dollarDisplay(recentTxs[r].value)}<span style={{opacity:0.33}}>-></span>
+              <span style={{ opacity: 0.33 }}>-</span>
+              {dollarDisplay(recentTxs[r].value)}
+              <span style={{ opacity: 0.33 }}>-&gt;</span>
             </span>
-          )
-        }else{
+          );
+        } else {
           dollarView = (
-            <span style={{opacity:0.5,fontSize:14}}>
+            <span style={{ opacity: 0.5, fontSize: 14 }}>
               {dollarDisplay(recentTxs[r].value)}
             </span>
-          )
+          );
         }
-
       } else {
-        //dollarDisplay
         dollarView = (
           <span>
-            <span style={{opacity:0.33}}>-</span>{dollarDisplay(recentTxs[r].value)}<span style={{opacity:0.33}}>-></span>
+            <span style={{ opacity: 0.33 }}>-</span>
+            {dollarDisplay(recentTxs[r].value)}
+            <span style={{ opacity: 0.33 }}>-&gt;</span>
           </span>
-        )
+        );
       }
 
       let toBlockie = (
-        <Blockie
-          address={recentTxs[r].to}
-          config={{size:4}}
-        />
-      )
-      if(recentTxs[r].to==address && recentTxs[r].data) {
-        let message = recentTxs[r].data
-        let limit = 18
-        if(message.length>limit){
-          message = message.substring(0,limit-3)+"..."
+        <Blockie address={recentTxs[r].to} config={{ size: 4 }} />
+      );
+      if (recentTxs[r].to === address && recentTxs[r].data) {
+        let message = recentTxs[r].data;
+        let limit = 18;
+        if (message.length > limit) {
+          message = message.substring(0, limit - 3) + "...";
         }
-        toBlockie = (
-          <span style={{fontSize:14}}>
-            {message}
-          </span>
-        )
+        toBlockie = <Text fontSize={2}>{message}</Text>;
       }
 
-      if(count++<max){
-        //if(txns.length>0){
-          txns.push(
-            <hr key={"ruler"+recentTxs[r].hash} style={{ "color": "#DFDFDF",marginTop:0,marginBottom:7 }}/>
-          )
-        //}
+      if (count++ < max) {
+        txns.push(
+          <hr key={"ruler" + recentTxs[r].hash} style={{ color: "#DFDFDF", marginTop: 0, marginBottom: 7 }} />
+        );
 
-        let blockAge = block-recentTxs[r].blockNumber
+        let blockAge = block - recentTxs[r].blockNumber;
+        let onClick = () => {
+          if (recentTxs[r].from === address) {
+            changeView("account_" + recentTxs[r].to);
+          } else {
+            changeView("account_" + recentTxs[r].from);
+          }
+        };
 
-        if(blockAge<=1&&recentTxs[r].to==address){
+        if (blockAge <= 1 && recentTxs[r].to === address) {
           txns.push(
-            <div key={"green"+count} style={{position:'relative',cursor:'pointer',paddingTop:10,paddingBottom:10}} key={recentTxs[r].hash} className="content bridge row" onClick={()=>{
-              if(recentTxs[r].from==address){
-                changeView("account_"+recentTxs[r].to)
-              }else{
-                changeView("account_"+recentTxs[r].from)
-              }
-            }}>
-              <div className="col-3" style={{textAlign:'center'}}>
-                <i className="fas fa-check-circle" style={{color:"#39e917",fontSize:70,opacity:.7}}></i>
-              </div>
-              <div className="col-3" style={{textAlign:'center',paddingTop:6}}>
-                <Blockie
-                  address={recentTxs[r].from}
-                  config={{size:7}}
-                />
-              </div>
-              <div className="col-3" style={{textAlign:'center',paddingTop:15,whiteSpace:"nowrap",letterSpacing:-1}}>
-                <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
+            <Flex
+              key={"green" + recentTxs[r].hash}
+              alignItems="center"
+              style={{ position: 'relative', cursor: 'pointer', paddingTop: 10, paddingBottom: 10 }}
+              onClick={onClick}
+            >
+              <Box width={3 / 12} textAlign="center">
+                <Icon name="CheckCircle" color="#39e917" size={48} style={{ opacity: 0.7 }} />
+              </Box>
+              <Box width={3 / 12} textAlign="center" pt={2}>
+                <Blockie address={recentTxs[r].from} config={{ size: 7 }} />
+              </Box>
+              <Box width={3 / 12} textAlign="center" pt={3}>
+                <Scaler config={{ startZoomAt: 400, origin: "50% 50%" }}>
                   {dollarView}
                 </Scaler>
-              </div>
-              <div className="col-3" style={{textAlign:'center',paddingTop:15,whiteSpace:"nowrap",letterSpacing:-1}}>
+              </Box>
+              <Box width={3 / 12} textAlign="center" pt={3}>
                 {toBlockie}
-              </div>
-            </div>
-          )
-        }else{
+              </Box>
+            </Flex>
+          );
+        } else {
           txns.push(
-            <div key={count} style={{position:'relative',cursor:'pointer'}} key={recentTxs[r].hash} className="content bridge row" onClick={()=>{
-              if(recentTxs[r].from==address){
-                changeView("account_"+recentTxs[r].to)
-              }else{
-                changeView("account_"+recentTxs[r].from)
-              }
-            }}>
+            <Flex
+              key={recentTxs[r].hash}
+              alignItems="center"
+              style={{ position: 'relative', cursor: 'pointer' }}
+              onClick={onClick}
+            >
               {extraIcon}
-              <div className="col-3 p-1" style={{textAlign:'center'}}>
-                <Blockie
-                  address={recentTxs[r].from}
-                  config={{size:4}}
-                />
-              </div>
-              <div className="col-3 p-1" style={{textAlign:'center',whiteSpace:"nowrap",letterSpacing:-1}}>
-                <Scaler config={{startZoomAt:600,origin:"25% 50%",adjustedZoom:1}}>
+              <Box width={3 / 12} px={1} textAlign="center">
+                <Blockie address={recentTxs[r].from} config={{ size: 4 }} />
+              </Box>
+              <Box width={3 / 12} px={1} textAlign="center">
+                <Scaler config={{ startZoomAt: 600, origin: "25% 50%", adjustedZoom: 1 }}>
                   {dollarView}
                 </Scaler>
-              </div>
-              <div className="col-3 p-1" style={{textAlign:'center',whiteSpace:"nowrap",letterSpacing:-1}}>
+              </Box>
+              <Box width={3 / 12} px={1} textAlign="center">
                 {toBlockie}
-              </div>
-              <div className="col-2 p-1" style={{textAlign:'center',whiteSpace:"nowrap",letterSpacing:-1}}>
-                <Scaler config={{startZoomAt:600,origin:"25% 50%",adjustedZoom:1}}>
-                <span style={{marginLeft:5,marginTop:-5,opacity:0.4,fontSize:12}}>{cleanTime((blockAge)*5)} ago</span>
+              </Box>
+              <Box width={3 / 12} px={1} textAlign="center">
+                <Scaler config={{ startZoomAt: 600, origin: "25% 50%", adjustedZoom: 1 }}>
+                  <Text ml={2} mt={-2} opacity={0.4} fontSize={1}>
+                    {cleanTime(blockAge * 5)} ago
+                  </Text>
                 </Scaler>
-              </div>
-
-            </div>
-          )
+              </Box>
+            </Flex>
+          );
         }
-
-
       }
-
     }
   }
-  if(txns.length>0){
-    return (
-      <div style={{marginTop:30}}>
-        {txns}
-      </div>
-    )
-  }else{
-    return (
-      <span></span>
-    )
-  }
-}
 
-let cleanTime = (s)=>{
-  if(s<60){
-    return s+"s"
-  }else if(s/60<60){
-    return Math.round(s/6)/10+"m"
-  }else {
-    return Math.round((s/60/6)/24)/10+"d"
+  if (txns.length > 0) {
+    return <Box mt={4}>{txns}</Box>;
   }
-}
+  return <span />;
+};
+
+let cleanTime = (s) => {
+  if (s < 60) return s + "s";
+  if (s / 60 < 60) return Math.round(s / 6) / 10 + "m";
+  return Math.round((s / 60 / 6) / 24) / 10 + "d";
+};

--- a/src/components/SendByScan.js
+++ b/src/components/SendByScan.js
@@ -5,6 +5,7 @@ import QrCode from 'qrcode-reader';
 import qrimage from '../qrcode.png';
 import RNMessageChannel from 'react-native-webview-messaging';
 import i18n from "../i18n";
+import { Button, Box } from 'rimble-ui';
 var Jimp = require("jimp");
 let interval
 class SendByScan extends Component {
@@ -230,16 +231,13 @@ class SendByScan extends Component {
             <div style={{marginBottom:20}}><i className="fas fa-camera"></i></div>
             <img src={qrimage} style={{position:"absolute",left:"36%",top:"25%",padding:4,border:"1px solid #888888",opacity:0.25,maxWidth:"30%",maxHight:"30%"}} />
           </div>
-          <div style={{textAlign:"center",paddingTop:"35%"}}>
-
-            <div>{i18n.t('send_by_scan.capture')}</div>
-              <div className="main-card card w-100" style={{backgroundColor:"#000000"}}>
-                <div className="content ops row" style={{paddingLeft:"12%",paddingRight:"12%",paddingTop:10}}>
-                    <button className="btn btn-large w-100" style={{backgroundColor:this.props.mainStyle.mainColor}}>
-                        <i className="fas fa-camera"  /> {i18n.t('send_by_scan.take_photo')}
-                    </button>
-                </div>
-              </div>
+            <div style={{textAlign:"center",paddingTop:"35%"}}>
+              <div>{i18n.t('send_by_scan.capture')}</div>
+              <Box px="12%" pt={3}>
+                <Button icon="Camera" width={1}>
+                  {i18n.t('send_by_scan.take_photo')}
+                </Button>
+              </Box>
             </div>
             <div style={{textAlign:"center",paddingTop:"5%"}}>
               Lay QR flat and take a picture of it from a distance.

--- a/src/components/ShareLink.js
+++ b/src/components/ShareLink.js
@@ -1,63 +1,49 @@
 import React from 'react';
 import Ruler from "./Ruler";
-import Balance from "./Balance";
-import Blockies from 'react-blockies';
-import {CopyToClipboard} from 'react-copy-to-clipboard';
-import { Scaler, Button } from "dapparatus"
-var QRCode = require('qrcode.react');
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+import {
+  Box,
+  Flex,
+  Input,
+  QR as QRCode
+} from 'rimble-ui';
 
 export default class ShareLink extends React.Component {
-
   constructor(props) {
     super(props);
     this.state = {
       copied: false
-    }
+    };
   }
+
   render() {
-    let { canSend } = this.state;
-
-    let port = window.location.port
-    if(port && port!="80"){
-      port=":"+port
-    }else{
-      port=""
+    let port = window.location.port;
+    if (port && port !== "80") {
+      port = ":" + port;
+    } else {
+      port = "";
     }
 
-    let url = window.location.protocol + "//" + window.location.hostname+port;
-    let element = "";
+    let url = window.location.protocol + "//" + window.location.hostname + port;
     let qrValue = url + "/" + this.props.sendLink + ";" + this.props.sendKey;
-    let extraDisplay = "";
-
-    let qrSize = Math.min(document.documentElement.clientWidth,512)-90
-
-
-    if(this.state.copied){
-      extraDisplay="Copied Link!"
-    }
+    let qrSize = Math.min(document.documentElement.clientWidth, 512) - 90;
 
     return (
       <div>
         <CopyToClipboard text={qrValue} onCopy={() => {
-               this.props.changeAlert({type: 'success', message: 'Link copied to clipboard'})
+          this.props.changeAlert({ type: 'success', message: 'Link copied to clipboard' });
         }}>
-        <div style={{cursor:"pointer"}}>
-          <div className="content qr row">
-            <QRCode value={qrValue} size={qrSize}/>
-          </div>
-          <Ruler/>
-          <div style={{width:"100%",textAlign:"center"}}>
-            <div className="input-group" style={{paddingLeft:20,paddingRight:20}}>
-              <input type="text" className="form-control" value={qrValue} disabled/>
-              <div className="input-group-append">
-                <span className="input-group-text"><i className="fas fa-copy"/></span>
-              </div>
-            </div>
-          </div>
-
-        </div>
+          <Box style={{ cursor: "pointer" }}>
+            <Flex flexDirection="column" alignItems="center" p={3}>
+              <QRCode value={qrValue} size={qrSize} renderAs="svg" />
+            </Flex>
+            <Ruler />
+            <Box px={3}>
+              <Input type="url" readOnly value={qrValue} width={1} />
+            </Box>
+          </Box>
         </CopyToClipboard>
       </div>
-    )
+    );
   }
 }

--- a/src/components/Vendor.js
+++ b/src/components/Vendor.js
@@ -1,201 +1,182 @@
 import React from 'react';
 import { Scaler } from "dapparatus";
-import Blockies from 'react-blockies';
-import Ruler from "./Ruler";
-import {CopyToClipboard} from "react-copy-to-clipboard";
 import i18n from '../i18n';
-const QRCode = require('qrcode.react');
+import {
+  Box,
+  Button,
+  Card,
+  Field,
+  Flex,
+  Input,
+  Text
+} from 'rimble-ui';
 
-let interval
-let metaReceiptTracker = {}
+let metaReceiptTracker = {};
 
-export default class Advanced extends React.Component {
-
+export default class Vendor extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       changingAvailable: {}
-    }
+    };
   }
-  render(){
-    let {dollarDisplay,buttonStyle,contracts,vendor,tx,web3} = this.props
 
-    let products = []
-    for(let p in this.props.products){
-      let prod = this.props.products[p]
-      if(prod.exists){
+  render() {
+    let { dollarDisplay, buttonStyle, contracts, vendor, tx, web3 } = this.props;
 
-        //console.log(prod)
-
-        let productAvailableDisplay = ""
-        if(this.state.changingAvailable[p]){
-          productAvailableDisplay = (
-            <i className="fas fa-cog fa-spin"></i>
-          )
-        }else if(prod.isAvailable){
-          productAvailableDisplay = (
-            <i className="fas fa-eye"></i>
-          )
-        }else{
-          productAvailableDisplay = (
-            <i className="fas fa-eye-slash"></i>
-          )
+    let products = [];
+    for (let p in this.props.products) {
+      let prod = this.props.products[p];
+      if (prod.exists) {
+        let productAvailableDisplay;
+        if (this.state.changingAvailable[p]) {
+          productAvailableDisplay = <i className="fas fa-cog fa-spin" />;
+        } else if (prod.isAvailable) {
+          productAvailableDisplay = <i className="fas fa-eye" />;
+        } else {
+          productAvailableDisplay = <i className="fas fa-eye-slash" />;
         }
 
-        let productIsActive = (
-          <button className="btn btn-large w-100"
-            onClick={()=>{
-              let changingAvailable = this.state.changingAvailable
-              changingAvailable[p] = true
-              this.setState({changingAvailable})
-              //addProduct(uint256 id, bytes32 name, uint256 cost, bool isAvailable)
-              console.log(prod.id,prod.name,prod.cost,prod.isAvailable)
-              tx(contracts[this.props.ERC20VENDOR].addProduct(prod.id,prod.name,prod.cost,!prod.isAvailable),240000,0,0,(result)=>{
-                console.log("===PRODUCT:",result)
-                let changingAvailable = this.state.changingAvailable
-                changingAvailable[p] = false
-
-                this.setState({changingAvailable})
-                setTimeout(this.poll.bind(this),444)
-              })
-            }}
-            style={buttonStyle.secondary}>
-            <Scaler config={{startZoomAt:500,origin:"50% 50%"}}>
-              {productAvailableDisplay}
-            </Scaler>
-          </button>
-        )
-
-        let available = (
-          <i className="far fa-eye"></i>
-        )
-        if(!prod.isAvailable){
-          available = (
-            <i className="far fa-eye" style={{opacity:0.3}}></i>
-          )
-        }
-
-        let opacity  =  1.0
-        if(!prod.isAvailable){
-          opacity = 0.5
-        }
+        let opacity = prod.isAvailable ? 1.0 : 0.5;
 
         products.push(
-          <div key={p} className="content bridge row" style={{opacity}}>
-            <div className="col-6 p-1">
-              {web3.utils.hexToUtf8(prod.name)}
-            </div>
-            <div className="col-4 p-1">
-              {dollarDisplay(web3.utils.fromWei(prod.cost,'ether'))}
-            </div>
-            <div className="col-2 p-1">
-              {productIsActive}
-            </div>
-          </div>
-        )
+          <Flex key={p} alignItems="center" mx={-1} mb={2} style={{ opacity }}>
+            <Box width={6 / 12} px={1}>
+              <Text>{web3.utils.hexToUtf8(prod.name)}</Text>
+            </Box>
+            <Box width={4 / 12} px={1}>
+              <Text>{dollarDisplay(web3.utils.fromWei(prod.cost, 'ether'))}</Text>
+            </Box>
+            <Box width={2 / 12} px={1}>
+              <Button
+                width={1}
+                onClick={() => {
+                  let changingAvailable = { ...this.state.changingAvailable };
+                  changingAvailable[p] = true;
+                  this.setState({ changingAvailable });
+                  tx(
+                    contracts[this.props.ERC20VENDOR].addProduct(
+                      prod.id, prod.name, prod.cost, !prod.isAvailable
+                    ),
+                    240000, 0, 0,
+                    () => {
+                      changingAvailable = { ...this.state.changingAvailable };
+                      changingAvailable[p] = false;
+                      this.setState({ changingAvailable });
+                      if (this.poll) setTimeout(this.poll.bind(this), 444);
+                    }
+                  );
+                }}
+              >
+                <Scaler config={{ startZoomAt: 500, origin: "50% 50%" }}>
+                  {productAvailableDisplay}
+                </Scaler>
+              </Button>
+            </Box>
+          </Flex>
+        );
       }
     }
 
-    let venderButtonText = ""
-    if(this.state.changingActive){
-      venderButtonText = (
-          <div>
-            <i className="fas fa-cog fa-spin"></i> {i18n.t('vendor.updating')}
-          </div>
-      )
-    }else if(vendor.isActive){
-      venderButtonText = (
-          <div>
-            <i className="fas fa-thumbs-up"></i> {i18n.t('vendor.open')}
-          </div>
-      )
-    }else{
-      venderButtonText = (
-        <div>
-          <i className="fas fa-thumbs-down"></i> {i18n.t('vendor.closed')}
-        </div>
-      )
+    let venderButtonText;
+    if (this.state.changingActive) {
+      venderButtonText = <><i className="fas fa-cog fa-spin" /> {i18n.t('vendor.updating')}</>;
+    } else if (vendor.isActive) {
+      venderButtonText = <><i className="fas fa-thumbs-up" /> {i18n.t('vendor.open')}</>;
+    } else {
+      venderButtonText = <><i className="fas fa-thumbs-down" /> {i18n.t('vendor.closed')}</>;
     }
 
-    let addProductText = (
-      <span>
-        <i className="fas fa-plus-square"></i> {i18n.t('vendor.add_product')}
-      </span>
-    )
-
-    if(this.state.addingProduct){
-      addProductText = (
-        <span>
-          <i className="fas fa-cog fa-spin"></i> {i18n.t('vendor.adding')}
-        </span>
-      )
-    }
-
+    let addProductText = this.state.addingProduct
+      ? <><i className="fas fa-cog fa-spin" /> {i18n.t('vendor.adding')}</>
+      : <><i className="fas fa-plus-square" /> {i18n.t('vendor.add_product')}</>;
 
     return (
-      <div className="main-card card w-100">
-        <div className="content bridge row">
-          <div className="col-8 p-1" style={{textAlign:'center'}}>
-            <h2>{web3.utils.hexToUtf8(vendor.name)}</h2>
-          </div>
-          <div className="col-4 p-1">
-          <button className="btn btn-large w-100" style={buttonStyle.secondary} onClick={()=>{
-            this.setState({changingActive:true})
-            let setActiveTo = !vendor.isActive
-            tx(contracts[this.props.ERC20VENDOR].activateVendor(setActiveTo),120000,0,0,(result)=>{
-              console.log("ACTIVE:",result)
-              setTimeout(()=>{
-                this.setState({changingActive:false})
-              },1500)
-            })
-          }}>
-            <Scaler config={{startZoomAt:500,origin:"40% 50%"}}>
-              {venderButtonText}
-            </Scaler>
-          </button>
-          </div>
-        </div>
-        {products}
-        <div className="content bridge row">
-          <div className="col-4 p-1">
-            <input type="text" className="form-control" placeholder="Name..." value={this.state.newProductName}
-                   onChange={event => this.setState({newProductName:event.target.value})} />
-          </div>
-          <div className="col-4 p-1">
-          <div className="input-group">
-            <div className="input-group-prepend">
-              <div className="input-group-text">$</div>
-            </div>
-            <input type="number" step="0.1" className="form-control" placeholder="0.00" value={this.state.newProductAmount}
-              onChange={event => this.setState({newProductAmount:event.target.value})} />
-          </div>
-          </div>
-          <div className="col-4 p-1">
-          <button className="btn btn-large w-100" style={buttonStyle.secondary} onClick={()=>{
-            if(!this.state.newProductName || !this.state.newProductAmount){
-              this.props.changeAlert({type: 'warning', message: 'Please enter a valid product and price.'})
-            }else{
-              //addProduct(uint256 id, bytes32 name, uint256 cost, bool isAvailable)
-              let nextId = this.props.products.length
-              this.setState({addingProduct:true})
-              tx(contracts[this.props.ERC20VENDOR].addProduct(nextId,web3.utils.utf8ToHex(this.state.newProductName),web3.utils.toWei(""+this.state.newProductAmount, 'ether'),true),240000,0,0,(receipt)=>{
-                console.log("PRODUCT ADDED",receipt)
-                if(receipt&&receipt.transactionHash&&!metaReceiptTracker[receipt.transactionHash]){
-                  metaReceiptTracker[receipt.transactionHash] = true
-                  this.setState({addingProduct:false,newProductAmount:"",newProductName:""})
-                  setTimeout(this.poll.bind(this),100)
-                }
-              })
-            }
+      <Card width={1}>
+        <Flex alignItems="center" mx={-1} mb={3}>
+          <Box width={8 / 12} px={1} textAlign="center">
+            <Text fontSize={5} fontWeight="bold">{web3.utils.hexToUtf8(vendor.name)}</Text>
+          </Box>
+          <Box width={4 / 12} px={1}>
+            <Button
+              width={1}
+              onClick={() => {
+                this.setState({ changingActive: true });
+                let setActiveTo = !vendor.isActive;
+                tx(
+                  contracts[this.props.ERC20VENDOR].activateVendor(setActiveTo),
+                  120000, 0, 0,
+                  () => {
+                    setTimeout(() => { this.setState({ changingActive: false }); }, 1500);
+                  }
+                );
+              }}
+            >
+              <Scaler config={{ startZoomAt: 500, origin: "40% 50%" }}>
+                {venderButtonText}
+              </Scaler>
+            </Button>
+          </Box>
+        </Flex>
 
-          }}>
-            <Scaler config={{startZoomAt:650,origin:"20% 50%"}}>
-              {addProductText}
-            </Scaler>
-          </button>
-          </div>
-        </div>
-      </div>
-    )
+        {products}
+
+        <Flex alignItems="flex-end" mx={-1} mt={3}>
+          <Box width={4 / 12} px={1}>
+            <Field label="Name">
+              <Input
+                placeholder="Name..."
+                value={this.state.newProductName || ''}
+                onChange={event => this.setState({ newProductName: event.target.value })}
+              />
+            </Field>
+          </Box>
+          <Box width={4 / 12} px={1}>
+            <Field label="Price">
+              <Input
+                type="number"
+                step="0.1"
+                placeholder="0.00"
+                value={this.state.newProductAmount || ''}
+                onChange={event => this.setState({ newProductAmount: event.target.value })}
+              />
+            </Field>
+          </Box>
+          <Box width={4 / 12} px={1}>
+            <Button
+              width={1}
+              onClick={() => {
+                if (!this.state.newProductName || !this.state.newProductAmount) {
+                  this.props.changeAlert({ type: 'warning', message: 'Please enter a valid product and price.' });
+                } else {
+                  let nextId = this.props.products.length;
+                  this.setState({ addingProduct: true });
+                  tx(
+                    contracts[this.props.ERC20VENDOR].addProduct(
+                      nextId,
+                      web3.utils.utf8ToHex(this.state.newProductName),
+                      web3.utils.toWei("" + this.state.newProductAmount, 'ether'),
+                      true
+                    ),
+                    240000, 0, 0,
+                    (receipt) => {
+                      if (receipt && receipt.transactionHash && !metaReceiptTracker[receipt.transactionHash]) {
+                        metaReceiptTracker[receipt.transactionHash] = true;
+                        this.setState({ addingProduct: false, newProductAmount: "", newProductName: "" });
+                        if (this.poll) setTimeout(this.poll.bind(this), 100);
+                      }
+                    }
+                  );
+                }
+              }}
+            >
+              <Scaler config={{ startZoomAt: 650, origin: "20% 50%" }}>
+                {addProductText}
+              </Scaler>
+            </Button>
+          </Box>
+        </Flex>
+      </Card>
+    );
   }
 }

--- a/src/components/Vendors.js
+++ b/src/components/Vendors.js
@@ -1,227 +1,212 @@
 import React from 'react';
-import { Scaler, Events } from "dapparatus";
+import { Scaler } from "dapparatus";
 import Blockies from 'react-blockies';
-import Ruler from "./Ruler";
-import {CopyToClipboard} from "react-copy-to-clipboard";
-const QRCode = require('qrcode.react');
+import {
+  Box,
+  Button,
+  Card,
+  Flex,
+  Icon,
+  QR as QRCode,
+  Text
+} from 'rimble-ui';
 
-let interval
+let interval;
 
-export default class Advanced extends React.Component {
-
+export default class Vendors extends React.Component {
   constructor(props) {
     super(props);
-    let vendor = false
-    if(window.location.pathname.indexOf("/vendors;")==0){
-      vendor = window.location.pathname.replace("/vendors;","")
-      window.history.pushState({},"", "/");
+    let vendor = false;
+    if (window.location.pathname.indexOf("/vendors;") === 0) {
+      vendor = window.location.pathname.replace("/vendors;", "");
+      window.history.pushState({}, "", "/");
     }
     this.state = {
       vendor: vendor,
       vendorObject: false,
       loading: false,
       showQR: {}
+    };
+  }
+
+  componentDidMount() {
+    interval = setInterval(this.poll.bind(this), 3000);
+    setTimeout(this.poll.bind(this), 444);
+  }
+
+  componentWillUnmount() {
+    clearInterval(interval);
+  }
+
+  async poll() {
+    let id = 0;
+    if (this.state.vendor) {
+      if (!this.state.vendorObject) {
+        let vendorData = await this.props.contracts[this.props.ERC20VENDOR].vendors(this.state.vendor).call();
+        vendorData.name = this.props.web3.utils.hexToUtf8(vendorData.name);
+        this.setState({ vendorObject: vendorData });
+      }
+      let products = [];
+      let found = true;
+      while (found) {
+        let nextProduct = await this.props.contracts[this.props.ERC20VENDOR].products(this.state.vendor, id).call();
+        if (nextProduct.exists) {
+          products[id++] = nextProduct;
+        } else {
+          found = false;
+        }
+      }
+      this.setState({ products, loading: false });
+    } else {
+      this.setState({ loading: false });
     }
   }
-  componentDidMount(){
-    interval = setInterval(this.poll.bind(this),3000)
-    setTimeout(this.poll.bind(this),444)
-  }
-  componentWillUnmount(){
-    clearInterval(interval)
-  }
-  async poll(){
-    let id = 0
-    if(this.state.vendor){
-     if(!this.state.vendorObject){
-       let vendorData = await this.props.contracts[this.props.ERC20VENDOR].vendors(this.state.vendor).call()
-       console.log("vendorData",vendorData)
-       vendorData.name = this.props.web3.utils.hexToUtf8(vendorData.name)
-       this.setState({vendorObject:vendorData})
-     }
-     console.log("Looking up products for vendor ",this.state.vendor)
-     let products = []//this.state.products
-     if(!products){
-       products = []
-     }
-     let found = true
-     while(found){
-       let nextProduct = await this.props.contracts[this.props.ERC20VENDOR].products(this.state.vendor,id).call()
-       if(nextProduct.exists){
-         products[id++] = nextProduct
-       }else{
-         found=false
-       }
-     }
-     this.setState({products,loading:false})
-    }else{
 
-     this.setState({loading:false})
-    }
-  }
-  render(){
-    let {mainStyle,contracts,tx,web3,vendors,dollarDisplay,vendorObject} = this.props
+  render() {
+    let { mainStyle, vendors, dollarDisplay, vendorObject } = this.props;
+    let { vendor } = this.state;
 
-    let {vendor} = this.state
-
-    let url = window.location.protocol+"//"+window.location.hostname
-    if(window.location.port&&window.location.port!=80&&window.location.port!=443){
-      url = url+":"+window.location.port
+    let url = window.location.protocol + "//" + window.location.hostname;
+    if (window.location.port && window.location.port !== 80 && window.location.port !== 443) {
+      url = url + ":" + window.location.port;
     }
 
-    let correctVendorObject = this.state.vendorObject
-    if(!correctVendorObject) correctVendorObject = vendorObject
+    let correctVendorObject = this.state.vendorObject || vendorObject;
+    let products = [];
+    let vendorDisplay = [];
 
-    let products = []
-    let vendorDisplay = []
-    if(vendor){
-      if(correctVendorObject){
+    if (vendor) {
+      if (correctVendorObject) {
         products.push(
-          <div className="nav-card card">
-            <div className="row">
-
-              <div style={{position:'absolute',left:10,fontSize:42,top:0,cursor:'pointer',zIndex:1,padding:3}} onClick={()=>{this.setState({vendor:false})}}>
-                <i className="fas fa-arrow-left" />
-              </div>
-
-              <div style={{textAlign:"center",width:"100%",fontSize:22}}>
-                <Scaler config={{startZoomAt:500,origin:"80% 50%",adjustedZoom:1}}>
+          <Card key="vendor-header" width={1} mb={3}>
+            <Box position="relative">
+              <Box
+                position="absolute"
+                left={0}
+                top={0}
+                style={{ fontSize: 42, cursor: 'pointer', zIndex: 1, padding: 3 }}
+                onClick={() => { this.setState({ vendor: false }); }}
+              >
+                <Icon name="ArrowBack" />
+              </Box>
+              <Text textAlign="center" width={1} fontSize={4}>
+                <Scaler config={{ startZoomAt: 500, origin: "80% 50%", adjustedZoom: 1 }}>
                   {correctVendorObject.name}
                 </Scaler>
-              </div>
-
-            </div>
-          </div>
-        )
+              </Text>
+            </Box>
+          </Card>
+        );
       }
 
-      let qrSize = Math.min(document.documentElement.clientWidth,512)-90
+      let qrSize = Math.min(document.documentElement.clientWidth, 512) - 90;
+      let correctProducts = this.state.products || this.props.products;
 
-      let correctProducts = this.state.products
-      if(!correctProducts) correctProducts=this.props.products
+      for (let p in correctProducts) {
+        let prod = correctProducts[p];
+        if (prod.exists && prod.isAvailable) {
+          let theName = this.props.web3.utils.hexToUtf8(prod.name);
+          let theAmount = this.props.web3.utils.fromWei(prod.cost, 'ether');
+          let productLocation = "/" + vendor + ";" + theAmount + ";" + theName.replace(/#/g, "%23").replace(/;/g, "%3B").replace(/:/g, "%3A").replace(/\//g, "%2F") + ";" + correctVendorObject.name + ":";
+          productLocation = encodeURI(productLocation);
+          let qrValue = url + productLocation;
 
-      for(let p in correctProducts){
-        let prod = correctProducts[p]
-        if(prod.exists&&prod.isAvailable){
+          let toggleQR = () => {
+            let showQR = { ...this.state.showQR };
+            showQR[p] = !showQR[p];
+            this.setState({ showQR });
+          };
 
-          let extraQR = ""
-
-          let theName = web3.utils.hexToUtf8(prod.name)
-          let theAmount = web3.utils.fromWei(prod.cost,'ether')
-
-          let productLocation = "/"+vendor+";"+theAmount+";"+theName.replaceAll("#","%23").replaceAll(";","%3B").replaceAll(":","%3A").replaceAll("/","%2F")+";"+correctVendorObject.name+":"
-
-          productLocation = encodeURI(productLocation)
-
-          let qrValue = url+productLocation
-
-          let toggleQR = () =>{
-            let {showQR} = this.state
-            showQR[p] = !showQR[p]
-            this.setState({showQR})
-          }
-
-          if(this.state.showQR[p]){
+          let extraQR = null;
+          if (this.state.showQR[p]) {
             extraQR = (
-              <div className="main-card card w-100" style={{paddingTop:40}} onClick={toggleQR}>
-                <div className="content qr row">
-                    <QRCode value={qrValue} size={qrSize}/>
-                    <div style={{width:'100%',textAlign:'center'}}><div>{correctVendorObject.name}</div>  {theName}:   {dollarDisplay(theAmount)}</div>
-                </div>
-              </div>
-            )
-          }
-
-
-          let available = (
-            <i className="far fa-eye"></i>
-          )
-          if(!prod.isAvailable){
-            available = (
-              <i className="far fa-eye" style={{opacity:0.3}}></i>
-            )
+              <Card width={1} mt={3} pt={4} onClick={toggleQR}>
+                <Flex flexDirection="column" alignItems="center">
+                  <QRCode value={qrValue} size={qrSize} renderAs="svg" />
+                  <Text textAlign="center" mt={3}>
+                    {correctVendorObject.name} {theName}: {dollarDisplay(theAmount)}
+                  </Text>
+                </Flex>
+              </Card>
+            );
           }
 
           products.push(
-            <div className="content bridge row" style={{borderBottom:"1px solid #dddddd",paddingTop:15,paddingBottom:10}}>
-              <div className="col-1 p-1" onClick={toggleQR}>
-                <i className="fas fa-qrcode"></i>
-              </div>
-              <div className="col-4 p-1">
-                {theName}
-              </div>
-              <div className="col-3 p-1">
-                ${dollarDisplay(theAmount)}
-              </div>
-              <div className="col-4 p-1">
-              <button className="btn btn-large w-100" style={{backgroundColor:mainStyle.mainColor,whiteSpace:"nowrap",marginTop:-8}} onClick={()=>{
-                this.setState({loading:true,products:false,vendor:false},()=>{
-                  window.location = productLocation
-                })
-
-              }}>
-                <Scaler config={{startZoomAt:500,origin:"40% 50%"}}>
-                  Purchase
-                </Scaler>
-              </button>
-              </div>
+            <Box key={p}>
+              <Flex alignItems="center" mx={-1} py={3} style={{ borderBottom: "1px solid #dddddd" }}>
+                <Box width={1 / 12} px={1} onClick={toggleQR} style={{ cursor: 'pointer' }}>
+                  <Icon name="CropFree" />
+                </Box>
+                <Box width={4 / 12} px={1}>{theName}</Box>
+                <Box width={3 / 12} px={1}>${dollarDisplay(theAmount)}</Box>
+                <Box width={4 / 12} px={1}>
+                  <Button
+                    width={1}
+                    onClick={() => {
+                      this.setState({ loading: true, products: false, vendor: false }, () => {
+                        window.location = productLocation;
+                      });
+                    }}
+                  >
+                    <Scaler config={{ startZoomAt: 500, origin: "40% 50%" }}>
+                      Purchase
+                    </Scaler>
+                  </Button>
+                </Box>
+              </Flex>
               {extraQR}
-            </div>
-          )
+            </Box>
+          );
         }
       }
 
-
-      let qrValue = url+"/vendors;"+this.state.vendor
-      if(vendorObject){
+      if (vendorObject) {
+        let qrValue = url + "/vendors;" + this.state.vendor;
         products.push(
-          <div className="main-card card w-100" style={{paddingTop:40}}>
-            <div className="content qr row">
-                <QRCode value={qrValue} size={qrSize}/>
-                <div style={{width:'100%',textAlign:'center'}}>{vendorObject.name}</div>
-            </div>
-          </div>
-        )
+          <Card key="vendor-qr" width={1} mt={3} pt={4}>
+            <Flex flexDirection="column" alignItems="center">
+              <QRCode value={qrValue} size={qrSize} renderAs="svg" />
+              <Text textAlign="center" mt={3}>{vendorObject.name}</Text>
+            </Flex>
+          </Card>
+        );
       }
-
-    }else{
-      for(let v in vendors){
-        if(vendors[v].isAllowed&&vendors[v].isActive){
-
-          let vendorButton = (
-            <button disabled={!vendors[v].isActive} className="btn btn-large w-100" style={{backgroundColor:mainStyle.mainColor,whiteSpace:"nowrap"}} onClick={()=>{
-                this.setState({loading:true,vendor:vendors[v].vendor,vendorObject:vendors[v]},()=>{
-                   this.poll()
-                })
-            }}>
-              <Scaler config={{startZoomAt:600,origin:"10% 50%"}}>
-                {vendors[v].name}
-              </Scaler>
-            </button>
-          )
+    } else {
+      for (let v in vendors) {
+        if (vendors[v].isAllowed && vendors[v].isActive) {
           vendorDisplay.push(
-            <div key={v} className="content bridge row">
-              <div className="col-2 p-1" style={{textAlign:'center'}}>
-                <Blockies seed={vendors[v].vendor.toLowerCase()} scale={5}/>
-              </div>
-              <div className="col-10 p-1" style={{textAlign:'center'}}>
-                {vendorButton}
-              </div>
-            </div>
-          )
+            <Flex key={v} alignItems="center" mx={-1} mb={2}>
+              <Box width={2 / 12} px={1} textAlign="center">
+                <Blockies seed={vendors[v].vendor.toLowerCase()} scale={5} />
+              </Box>
+              <Box width={10 / 12} px={1} textAlign="center">
+                <Button
+                  disabled={!vendors[v].isActive}
+                  width={1}
+                  onClick={() => {
+                    this.setState({
+                      loading: true,
+                      vendor: vendors[v].vendor,
+                      vendorObject: vendors[v]
+                    }, () => { this.poll(); });
+                  }}
+                >
+                  <Scaler config={{ startZoomAt: 600, origin: "10% 50%" }}>
+                    {vendors[v].name}
+                  </Scaler>
+                </Button>
+              </Box>
+            </Flex>
+          );
         }
       }
     }
 
-
-
     return (
-      <div>
-
-          {vendorDisplay}
-          {products}
-
-      </div>
-    )
+      <Box>
+        {vendorDisplay}
+        {products}
+      </Box>
+    );
   }
 }

--- a/src/components/WithdrawFromPrivate.js
+++ b/src/components/WithdrawFromPrivate.js
@@ -7,6 +7,9 @@ import Blockies from 'react-blockies';
 import i18n from '../i18n';
 import {
   Button,
+  Box,
+  Field,
+  Flex,
   Input
 } from 'rimble-ui'
 
@@ -128,94 +131,80 @@ export default class SendToAddress extends React.Component {
         if(prod.isAvailable){
           let costInDollars = this.props.web3.utils.fromWei(prod.cost,'ether')
           products.push(
-            <div key={p} className="content bridge row">
-              <div className="col-12 p-1">
-                <button className="btn btn-large w-100"
-                  onClick={()=>{
-                    console.log(prod.id,prod.name,prod.cost,prod.isAvailable)
-                    let currentAmount = this.state.amount
-                    if(currentAmount) currentAmount+=parseFloat(costInDollars)
-                    else currentAmount = parseFloat(costInDollars)
-                    if(currentAmount!=this.state.amount){
-                      this.setState({amount:currentAmount})
-                    }
-                  }}
-                  style={this.props.buttonStyle.secondary}>
-                  <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-                    {this.props.web3.utils.hexToUtf8(prod.name)} {this.props.dollarDisplay(costInDollars)}
-                  </Scaler>
-                </button>
-              </div>
-            </div>
-          )
+            <Box key={p} mb={2}>
+              <Button
+                width={1}
+                onClick={() => {
+                  let currentAmount = this.state.amount;
+                  if (currentAmount) currentAmount += parseFloat(costInDollars);
+                  else currentAmount = parseFloat(costInDollars);
+                  if (currentAmount !== this.state.amount) {
+                    this.setState({ amount: currentAmount });
+                  }
+                }}
+              >
+                <Scaler config={{ startZoomAt: 400, origin: "50% 50%" }}>
+                  {this.props.web3.utils.hexToUtf8(prod.name)} {this.props.dollarDisplay(costInDollars)}
+                </Scaler>
+              </Button>
+            </Box>
+          );
         }
 
       }
     }
     if(products.length>0){
       products.push(
-        <div key={"reset"} className="content bridge row">
-          <div className="col-12 p-1">
-            <button className="btn btn-large w-100"
-              onClick={()=>{
-                this.setState({amount:""})
-              }}
-              style={this.props.buttonStyle.secondary}>
-              <Scaler config={{startZoomAt:400,origin:"50% 50%"}}>
-                Reset
-              </Scaler>
-            </button>
-          </div>
-        </div>
-      )
+        <Box key="reset" mb={2}>
+          <Button width={1} onClick={() => { this.setState({ amount: "" }); }}>
+            <Scaler config={{ startZoomAt: 400, origin: "50% 50%" }}>
+              Reset
+            </Scaler>
+          </Button>
+        </Box>
+      );
     }
 
     return (
-      <div>
-          <div className="content row">
-            <div className="form-group w-100">
-              <div className="form-group w-100">
-                <label htmlFor="amount_input">{i18n.t('withdraw_from_private.from_address')}</label>
-                <Input
-                  width={1}
-                  type="text"
-                  placeholder="0x..."
-                  value={fromAddress} />
-              </div>
+      <Box>
+        <Field label={i18n.t('withdraw_from_private.from_address')} mb={3}>
+          <Input type="text" placeholder="0x..." value={fromAddress} width={1} />
+        </Field>
 
-              <div className="content bridge row">
-                  <div className="col-6 p-1 w-100">
-                    { <Blockies seed={fromAddress} scale={10} /> }
-                  </div>
-                  <div className="col-6 p-1 w-100">
-                    <div style={{fontSize:64,letterSpacing:-2,fontWeight:500,whiteSpace:"nowrap"}}>
-                      <Scaler config={{startZoomAt:1000,origin:"0% 50%"}}>
-                        ${this.state.fromBalance}
-                      </Scaler>
-                    </div>
-                  </div>
-              </div>
+        <Flex alignItems="center" mb={3}>
+          <Box width={1 / 2}>
+            <Blockies seed={fromAddress} scale={10} />
+          </Box>
+          <Box width={1 / 2}>
+            <Box style={{ fontSize: 64, letterSpacing: -2, fontWeight: 500, whiteSpace: "nowrap" }}>
+              <Scaler config={{ startZoomAt: 1000, origin: "0% 50%" }}>
+                ${this.state.fromBalance}
+              </Scaler>
+            </Box>
+          </Box>
+        </Flex>
 
-              <label htmlFor="amount_input">{i18n.t('withdraw_from_private.amount')}</label>
-              <div className="input-group">
-                <Input 
-                  width={1}
-                  type="number"
-                  placeholder="$0.00"
-                  value={this.state.amount}
-                  onChange={event => this.updateState('amount', event.target.value)} />
-              </div>
-              {products}
-            </div>
-            <Button 
-              size={'large'}
-              width={1}
-              disabled={!canWithdraw}
-              onClick={this.withdraw}>
-              {i18n.t('withdraw_from_private.withdraw')}
-            </Button>
-          </div>
-      </div>
-    )
+        <Field label={i18n.t('withdraw_from_private.amount')} mb={3}>
+          <Input
+            width={1}
+            type="number"
+            placeholder="$0.00"
+            value={this.state.amount}
+            onChange={event => this.updateState('amount', event.target.value)}
+          />
+        </Field>
+
+        {products}
+
+        <Button
+          size="large"
+          width={1}
+          disabled={!canWithdraw}
+          onClick={this.withdraw}
+        >
+          {i18n.t('withdraw_from_private.withdraw')}
+        </Button>
+      </Box>
+    );
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import 'bootstrap/dist/css/bootstrap.min.css';
 import './index.scss';
 import App from './App';
 

--- a/src/services/wyre.js
+++ b/src/services/wyre.js
@@ -1,49 +1,62 @@
-/** Third Party **/
-const Wyre = window.Wyre;
-
 /** Constants **/
 const DEVICE_TOKEN__KEY = 'WYRE__DEVICE_TOKEN';
 
+function getWyreSdk() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  return window.Wyre || null;
+}
+
 class WyreWrapper {
-    async configure() {
-        let deviceToken = localStorage.getItem(DEVICE_TOKEN__KEY);
-        if (!deviceToken) {
-            let array = new Uint8Array(25);
-            window.crypto.getRandomValues(array);
-            deviceToken = Array.prototype.map.call(array, x => ('00' + x.toString(16)).slice(-2)).join('');
-            localStorage.setItem(DEVICE_TOKEN__KEY, deviceToken);
-        }
+  async configure() {
+    let deviceToken = localStorage.getItem(DEVICE_TOKEN__KEY);
+    if (!deviceToken) {
+      let array = new Uint8Array(25);
+      window.crypto.getRandomValues(array);
+      deviceToken = Array.prototype.map.call(array, x => ('00' + x.toString(16)).slice(-2)).join('');
+      localStorage.setItem(DEVICE_TOKEN__KEY, deviceToken);
+    }
+  }
+
+  displayWidget(
+    destinationAddress,
+    destinationAmount,
+    onClose = () => {},
+    onComplete = () => {}
+  ) {
+    const Wyre = getWyreSdk();
+    if (!Wyre || !Wyre.Widget) {
+      console.error('Wyre SDK not loaded — check widget-loader.js');
+      onClose();
+      return false;
     }
 
-    displayWidget(
-        destinationAddress,
-        destinationAmount,
-        onClose = () => {},
-        onComplete = () => {}
-    ) {
-        const deviceToken = localStorage.getItem(DEVICE_TOKEN__KEY);
+    const deviceToken = localStorage.getItem(DEVICE_TOKEN__KEY);
 
-        const widget = new Wyre.Widget({
-            env: 'prod',
-            accountId: 'AC-396YDETRHDJ',
-            auth: {
-                type: 'secretKey',
-                secretKey: deviceToken
-            },
-            operation: {
-                type: 'debitcard',
-                destCurrency: 'eth',
-                dest: `ethereum:${destinationAddress}`,
-                sourceAmount: parseInt(destinationAmount, 10),
-            }
-        });
+    const widget = new Wyre.Widget({
+      env: 'prod',
+      accountId: 'AC-396YDETRHDJ',
+      auth: {
+        type: 'secretKey',
+        secretKey: deviceToken
+      },
+      operation: {
+        type: 'debitcard',
+        destCurrency: 'eth',
+        dest: `ethereum:${destinationAddress}`,
+        sourceAmount: parseInt(destinationAmount, 10),
+      }
+    });
 
-        widget.on('complete', onComplete);
-        widget.on('close', onClose);
-        widget.on('ready', () => {
-            widget.open();
-        })
-    }
+    widget.on('complete', onComplete);
+    widget.on('close', onClose);
+    widget.on('ready', () => {
+      widget.open();
+    });
+
+    return true;
+  }
 }
 
 export default new WyreWrapper();

--- a/src/theme.js
+++ b/src/theme.js
@@ -40,7 +40,7 @@ export default {
     disabled: 0.4
   },
   colors: {
-    primary: '#4E3FCE',
+    primary: '#FF6700',
     blue: '#007ce0',
     navy: '#004175',
     copyColor: '#3F3D4B',


### PR DESCRIPTION
## Summary
Fixes #179 — `Cannot read property 'Widget' of undefined` on wyre.xdai.io.

**Root cause:** `wyre.js` captured `window.Wyre` at module load time, before `widget-loader.js` finished loading.

**Fix:**
- Resolve `window.Wyre` lazily inside `displayWidget()`
- Guard when SDK missing; show user-facing alert via Exchange
- Return `false` so UI resets loading state

## Test plan
- [ ] Open Exchange on localhost / wyre.xdai.io
- [ ] Click Buy button — widget opens OR friendly warning (no console crash)

Stacks on top of rimble-ui work in #309 (same `rim` branch).

— RoviDev (@rovidev95)
