### PR TITLE
ci: CD workflow + deploy docs (partial Fixes #203)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,75 @@
+name: Deploy
+
+on:
+  push:
+    branches: [rim, production]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 14.x
+          cache: npm
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+      - name: Build
+        run: npm run build
+        env:
+          CI: true
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: build/
+
+  deploy-staging:
+    needs: build
+    if: github.ref == 'refs/heads/rim' && github.repository == 'austintgriffith/burner-wallet'
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 14.x
+          cache: npm
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+      - name: Deploy to staging
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          S3_BUCKET: ${{ secrets.S3_BUCKET_STAGING }}
+          CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_STAGING }}
+        run: |
+          npm run build
+          chmod +x scripts/ci_deploy.sh
+          ./scripts/ci_deploy.sh
+
+  deploy-production:
+    needs: build
+    if: github.ref == 'refs/heads/production' && github.repository == 'austintgriffith/burner-wallet'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 14.x
+          cache: npm
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+      - name: Deploy to production
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          S3_BUCKET: ${{ secrets.S3_BUCKET_PRODUCTION }}
+          CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_PRODUCTION }}
+        run: |
+          npm run build
+          chmod +x scripts/ci_deploy.sh
+          ./scripts/ci_deploy.sh

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,45 @@
+# Deployment (bounty #203)
+
+Burner Wallet deploys to static hosting (S3 + CloudFront per leapdao/burner-wallet#144).
+
+## Branches
+
+| Branch | Target | Notes |
+|--------|--------|-------|
+| `rim` / `master` | Staging (`test.xdai.io` proposed) | Rinkeby/test networks |
+| `production` | Production (`xdai.io`) | Maintainer-only merges |
+
+See `docs/BRANCHING.md` for full git flow.
+
+## GitHub Actions
+
+`.github/workflows/deploy.yml` runs on push to `rim` and `production`:
+
+1. **build** — `npm run build`
+2. **deploy** — `scripts/ci_deploy.sh` (needs secrets below)
+
+## Required secrets (repository settings)
+
+| Secret | Purpose |
+|--------|---------|
+| `AWS_ACCESS_KEY_ID` | S3 upload |
+| `AWS_SECRET_ACCESS_KEY` | S3 upload |
+| `S3_BUCKET_STAGING` | Staging bucket name |
+| `S3_BUCKET_PRODUCTION` | Production bucket name |
+| `CLOUDFRONT_DISTRIBUTION_ID_STAGING` | Optional cache invalidation |
+| `CLOUDFRONT_DISTRIBUTION_ID_PRODUCTION` | Optional cache invalidation |
+
+@austintgriffith must add these secrets before deploy jobs run. Until then, the **build** job still validates production builds on every push.
+
+## Local deploy
+
+```bash
+npm install --legacy-peer-deps
+export S3_BUCKET=your-bucket
+export CLOUDFRONT_DISTRIBUTION_ID=your-distribution
+./scripts/ci_deploy.sh
+```
+
+## Legacy scripts
+
+`pushToRelay.sh` and similar manual scripts can be retired once CD is verified on staging.

--- a/scripts/ci_deploy.sh
+++ b/scripts/ci_deploy.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Continuous deployment script (leapdao/burner-wallet#144 pattern).
+# Requires: AWS CLI, S3_BUCKET, CLOUDFRONT_DISTRIBUTION_ID env vars.
+set -e
+
+npm run build
+
+if [ -z "$S3_BUCKET" ]; then
+  echo "S3_BUCKET not set — skipping S3 sync (build artifact only)."
+  exit 0
+fi
+
+aws s3 sync ./build "s3://${S3_BUCKET}/" --acl public-read
+
+if [ -n "$CLOUDFRONT_DISTRIBUTION_ID" ]; then
+  aws configure set preview.cloudfront true
+  aws cloudfront create-invalidation --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" --paths "/*"
+fi
+
+echo "Deploy complete."


### PR DESCRIPTION
Fixes #203 (partial)

CD pipeline per leapdao/burner-wallet#144 — **build always runs**; deploy needs AWS secrets from @austintgriffith.

- `.github/workflows/deploy.yml` — staging (`rim`) + production branches
- `scripts/ci_deploy.sh` — S3 + CloudFront invalidation
- `docs/DEPLOY.md` — secrets checklist

/claim #203 rovidev95@gmail.com

@TimDaub — please add `S3_BUCKET_STAGING`, `AWS_*` secrets to enable deploy jobs.
